### PR TITLE
Fix crash on opening map multiple times on Android device

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -86,4 +86,5 @@ flutter {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "com.google.android.gms:play-services-maps:$maps_version"
 }

--- a/android/app/src/main/kotlin/com/gskinner/wonders/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/gskinner/wonders/MainActivity.kt
@@ -1,6 +1,15 @@
 package com.gskinner.flutter.wonders
 
+import android.os.Bundle
+import com.google.android.gms.maps.MapsInitializer
+import com.google.android.gms.maps.OnMapsSdkInitializedCallback
 import io.flutter.embedding.android.FlutterActivity
 
-class MainActivity: FlutterActivity() {
+class MainActivity : FlutterActivity(), OnMapsSdkInitializedCallback {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        MapsInitializer.initialize(applicationContext, MapsInitializer.Renderer.LATEST, this)
+    }
+
+    override fun onMapsSdkInitialized(p0: MapsInitializer.Renderer) {}
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.6.10'
+    ext.maps_version = '18.1.0'
+
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
**OS:** 

- Android

**Reproduce steps:**

- Open Wondrous app
- Open an item detail and go on the bottom of the page
- Open and close the map multiple times

Crash details:

```
E/AndroidRuntime(26193): FATAL EXCEPTION: GLThread 128
E/AndroidRuntime(26193): Process: com.gskinner.flutter.wonders, PID: 26193
E/AndroidRuntime(26193): java.lang.NullPointerException: Attempt to get length of null array
E/AndroidRuntime(26193): 	at java.nio.ByteBufferAsIntBuffer.put(ByteBufferAsIntBuffer.java:122)
E/AndroidRuntime(26193): 	at com.google.maps.api.android.lib6.gmm6.vector.gl.buffer.j.l(:com.google.android.gms.dynamite_mapsdynamite@222615097@22.26.15 (190400-0):5)
E/AndroidRuntime(26193): 	at com.google.maps.api.android.lib6.gmm6.vector.gl.buffer.j.o(:com.google.android.gms.dynamite_mapsdynamite@222615097@22.26.15 (190400-0):1)
E/AndroidRuntime(26193): 	at com.google.maps.api.android.lib6.gmm6.vector.gl.buffer.j.g(:com.google.android.gms.dynamite_mapsdynamite@222615097@22.26.15 (190400-0):3)
E/AndroidRuntime(26193): 	at com.google.maps.api.android.lib6.gmm6.vector.gl.drawable.ai.s(:com.google.android.gms.dynamite_mapsdynamite@222615097@22.26.15 (190400-0):27)
E/AndroidRuntime(26193): 	at com.google.maps.api.android.lib6.gmm6.vector.gl.drawable.ao.s(:com.google.android.gms.dynamite_mapsdynamite@222615097@22.26.15 (190400-0):10)
E/AndroidRuntime(26193): 	at com.google.maps.api.android.lib6.gmm6.vector.bz.s(:com.google.android.gms.dynamite_mapsdynamite@222615097@22.26.15 (190400-0):29)
E/AndroidRuntime(26193): 	at com.google.maps.api.android.lib6.gmm6.vector.bs.b(:com.google.android.gms.dynamite_mapsdynamite@222615097@22.26.15 (190400-0):151)
E/AndroidRuntime(26193): 	at com.google.maps.api.android.lib6.gmm6.vector.an.run(:com.google.android.gms.dynamite_mapsdynamite@222615097@22.26.15 (190400-0):48)
I/ViewRootImpl@195755b[MainActivity](26193): ViewPostIme pointer 1
I/flutter (26193): Navigate to: /maps/greatWall
I/Process (26193): Sending signal. PID: 26193 SIG: 9
Lost connection to device.
```