### PR TITLE
Adding missing loader on fullscreen photo viewer

### DIFF
--- a/lib/ui/common/modals/fullscreen_url_img_viewer.dart
+++ b/lib/ui/common/modals/fullscreen_url_img_viewer.dart
@@ -91,9 +91,12 @@ class _ViewerState extends State<_Viewer> with SingleTickerProviderStateMixin {
         child: Hero(
           tag: widget.url,
           child: AppImage(
-            image: NetworkImage(widget.url),
+            image: NetworkImage(
+              widget.url,
+            ),
             fit: BoxFit.contain,
             scale: 2.5,
+            progress: true,
           ),
         ),
       ),


### PR DESCRIPTION
Reproduce steps:

- Set a slow network (like 2G)
- Click a photo on the gallery