### PR TITLE
fix : intro_screen next button clickable

### DIFF
--- a/lib/ui/screens/intro/intro_screen.dart
+++ b/lib/ui/screens/intro/intro_screen.dart
@@ -31,8 +31,10 @@ class _IntroScreenState extends State<IntroScreen> {
   }
 
   void _handleIntroCompletePressed() {
-    context.go(ScreenPaths.home);
-    settingsLogic.hasCompletedOnboarding.value = true;
+    if (_currentPage.value == pageData.length - 1) {
+      context.go(ScreenPaths.home);
+      settingsLogic.hasCompletedOnboarding.value = true;
+    }
   }
 
   void _handlePageChanged() {


### PR DESCRIPTION
When user is not in last screen of intro, the next button was hidden but still clickable when tapped in that area. Added a condition to check if user is on last page.
