### PR TITLE
Use GradientContainer to optimize raster performance

### DIFF
--- a/lib/ui/screens/editorial/widgets/_collapsing_pull_quote_image.dart
+++ b/lib/ui/screens/editorial/widgets/_collapsing_pull_quote_image.dart
@@ -116,7 +116,7 @@ class _CollapsingPullQuoteImage extends StatelessWidget {
     );
   }
 
-  Stack _buildImage(double collapseAmt) {
+  Widget _buildImage(double collapseAmt) {
     return Stack(
       fit: StackFit.expand,
       children: [
@@ -128,16 +128,13 @@ class _CollapsingPullQuoteImage extends StatelessWidget {
             opacity: AlwaysStoppedAnimation(1 - collapseAmt * .7),
           ),
         ),
-        BlendMask(
-          blendModes: const [BlendMode.colorBurn],
-          opacity: .9,
-          child: VtGradient(
-            [
-              Color(0xFFBEABA1).withOpacity(1),
-              Color(0xFFA6958C).withOpacity(1),
-            ],
-            const [0, 1],
-          ),
+        GradientContainer(
+          [
+            Color(0xFFBEABA1).withOpacity(.9),
+            Color(0xFFA6958C).withOpacity(.9),
+          ],
+          const [0.0, 1.0],
+          blendMode: BlendMode.colorBurn,
         ),
       ],
     );

--- a/lib/ui/screens/editorial/widgets/_collapsing_pull_quote_image.dart
+++ b/lib/ui/screens/editorial/widgets/_collapsing_pull_quote_image.dart
@@ -130,8 +130,8 @@ class _CollapsingPullQuoteImage extends StatelessWidget {
         ),
         GradientContainer(
           [
-            Color(0xFFBEABA1).withOpacity(.9),
-            Color(0xFFA6958C).withOpacity(.9),
+            Color(0xFFBEABA1).withOpacity(1),
+            Color(0xFFA6958C).withOpacity(1),
           ],
           const [0.0, 1.0],
           blendMode: BlendMode.colorBurn,


### PR DESCRIPTION
This optimization is part of the _CollapsingPullQuoteImage widget class, which is used on each Wonder screen. Switching from a BlendMask to a GradientContainer provides a 33% performance gain (3ms) on the rendering layer shown here. When each frame should render in 16ms, 3ms can be the difference between a janky frame and a performant frame.

Before:
<img width="894" alt="Screen Shot 2022-09-13 at 5 27 40 PM" src="https://user-images.githubusercontent.com/43759233/190032352-e6120508-9d55-45cd-a5b2-50a6931df8c7.png">

After:
<img width="899" alt="Screen Shot 2022-09-13 at 5 25 44 PM" src="https://user-images.githubusercontent.com/43759233/190032238-055e4028-bf74-4987-a89d-3e33af9a7252.png">

Before (left)    After (right)
<img src="https://user-images.githubusercontent.com/43759233/190030823-5565c6cb-343b-4268-bf1c-9d8c824f0768.jpeg"  width="300"> <img src="https://user-images.githubusercontent.com/43759233/190033730-06bc543d-d93a-4f5b-947a-3db2304f7468.jpeg"  width="300">

