### PR TITLE
Reduce Widget rebuilds on WonderEditorialScreen

### DIFF
--- a/lib/ui/common/scaling_list_item.dart
+++ b/lib/ui/common/scaling_list_item.dart
@@ -45,6 +45,7 @@ class ScalingListItem extends StatelessWidget {
       scrollPos: scrollPos,
       builder: (_, pctVisible) {
         final scale = 1.35 - pctVisible * .35;
+        // TODO: consider returning a SizedBox when scale == 0.
         return ClipRect(
           child: Transform.scale(scale: scale, child: child),
         );

--- a/lib/ui/screens/editorial/editorial_screen.dart
+++ b/lib/ui/screens/editorial/editorial_screen.dart
@@ -35,7 +35,8 @@ part 'widgets/_title_text.dart';
 part 'widgets/_top_illustration.dart';
 
 class WonderEditorialScreen extends StatefulWidget {
-  const WonderEditorialScreen(this.data, {Key? key, required this.onScroll}) : super(key: key);
+  const WonderEditorialScreen(this.data, {Key? key, required this.onScroll})
+      : super(key: key);
   final WonderData data;
   final void Function(double scrollPos) onScroll;
 
@@ -44,7 +45,8 @@ class WonderEditorialScreen extends StatefulWidget {
 }
 
 class _WonderEditorialScreenState extends State<WonderEditorialScreen> {
-  late final ScrollController _scroller = ScrollController()..addListener(_handleScrollChanged);
+  late final ScrollController _scroller = ScrollController()
+    ..addListener(_handleScrollChanged);
   final _scrollPos = ValueNotifier(0.0);
   final _sectionIndex = ValueNotifier(0);
   final _scrollToPopThreshold = 50;
@@ -156,7 +158,8 @@ class _WonderEditorialScreenState extends State<WonderEditorialScreen> {
                     return Opacity(opacity: opacity, child: child);
                   },
                   // This is due to a bug: https://github.com/flutter/flutter/issues/101872
-                  child: RepaintBoundary(child: _TopIllustration(widget.data.type)),
+                  child: RepaintBoundary(
+                      child: _TopIllustration(widget.data.type)),
                 ),
               ),
 
@@ -205,16 +208,20 @@ class _WonderEditorialScreenState extends State<WonderEditorialScreen> {
                         widget.data.type,
                         scrollPos: _scrollPos,
                         sectionIndex: _sectionIndex,
-                      ).animate().fade(duration: $styles.times.med, delay: $styles.times.pageTransition),
+                      ).animate().fade(
+                          duration: $styles.times.med,
+                          delay: $styles.times.pageTransition),
                     ),
                   ),
 
                   /// Editorial content (text and images)
-                  _ScrollingContent(widget.data, scrollPos: _scrollPos, sectionNotifier: _sectionIndex),
+                  _ScrollingContent(widget.data,
+                      scrollPos: _scrollPos, sectionNotifier: _sectionIndex),
 
                   /// Bottom padding
                   SliverToBoxAdapter(
-                    child: Container(height: 150, color: $styles.colors.offWhite),
+                    child:
+                        Container(height: 150, color: $styles.colors.offWhite),
                   ),
                 ],
               ),


### PR DESCRIPTION
Confirmed with the Widget rebuild stats tool in IntelliJ that this reduces unnecessary widget rebuilds. If a widget is completely transparent (opacity 0), there is no value for rebuilding and rendering - only cost. This PR reduces that.