### PR TITLE
Show the split view on Wonder Events screen for open foldable devices

### DIFF
--- a/lib/ui/screens/wonder_events/wonder_events.dart
+++ b/lib/ui/screens/wonder_events/wonder_events.dart
@@ -36,7 +36,9 @@ class WonderEvents extends StatelessWidget {
               /// Main view switches between portrait and landscape views
               Positioned.fill(
                 top: $styles.insets.sm,
-                child: context.isLandscape ? _buildLandscape(context) : _buildPortrait(),
+                child: context.isLandscape || MediaQuery.of(context).size.aspectRatio > .85
+                    ? _buildLandscape(context)
+                    : _buildPortrait(),
               ),
 
               /// Header w/ TimelineBtn


### PR DESCRIPTION
Foldable devices in an open state display the landscape version of the events page nicely! So I propose using this UI when the tablet is in landscape, or when the aspect ratio is above a certain threshold (representing open foldable devices). 

I tested a few fold devices (Fold4) / emulators (7.6 & 8) and it seemed that .85 was a good breakpoint for aspect ratio to display the event page. 

I also tried on the Surface Duo Android 12 emulator, but it was just contained to one screen, not quite sure how to get it to span both. 

There might be a better solution, this was just a thought :) 