### PR TITLE
Optimize advanced blend by reducing saveLayer count

### DIFF
--- a/lib/ui/screens/editorial/widgets/_collapsing_pull_quote_image.dart
+++ b/lib/ui/screens/editorial/widgets/_collapsing_pull_quote_image.dart
@@ -24,11 +24,9 @@ class _CollapsingPullQuoteImage extends StatelessWidget {
       double offsetY = (imgHeight / 2 + outerPadding * .25) * (1 - collapseAmt);
       if (top) offsetY *= -1; // flip?
       return Transform.translate(
-          offset: Offset(0, offsetY),
-          child: BlendMask(
-            blendModes: const [BlendMode.colorBurn],
-            child: Text(value, style: quoteStyle, textAlign: TextAlign.center),
-          ));
+        offset: Offset(0, offsetY),
+        child: Text(value, style: quoteStyle, textAlign: TextAlign.center),
+      );
     }
 
     return ValueListenableBuilder<double>(
@@ -89,19 +87,22 @@ class _CollapsingPullQuoteImage extends StatelessWidget {
                   child: Container(
                     margin: const EdgeInsets.symmetric(horizontal: 24),
                     child: StaticTextScale(
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          SizedBox(height: 32), // push down vertical centre
-                          buildText(data.pullQuote1Top, collapseAmt, top: true),
-                          buildText(data.pullQuote1Bottom, collapseAmt, top: false),
-                          if (data.pullQuote1Author.isNotEmpty) ...[
-                            Container(
-                              margin: const EdgeInsets.only(top: 16),
-                              child: buildText('- ${data.pullQuote1Author}', collapseAmt, top: false, isAuthor: true),
-                            )
+                      child: BlendMask(
+                        blendModes: const [BlendMode.colorBurn],
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            SizedBox(height: 32), // push down vertical centre
+                            buildText(data.pullQuote1Top, collapseAmt, top: true),
+                            buildText(data.pullQuote1Bottom, collapseAmt, top: false),
+                            if (data.pullQuote1Author.isNotEmpty) ...[
+                              Container(
+                                margin: const EdgeInsets.only(top: 16),
+                                child: buildText('- ${data.pullQuote1Author}', collapseAmt, top: false, isAuthor: true),
+                              )
+                            ],
                           ],
-                        ],
+                        ),
                       ),
                     ),
                   ),


### PR DESCRIPTION
See https://github.com/flutter/flutter/issues/120223 for more details

Advanced blends don't perform as well as they should right now because of the cost of blitting the resulting texture back onscreen is much higher in Impeller than Skia. While we're working on some mid term fixes, in the meantime the performance of the collapsing pullquote can be improved by reducing the number of save layers and combinging the advanced blend for the top and bottom quote.