### PR TITLE
Upgraded go_router to work with the latest version of Flutter.

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -36,6 +36,9 @@ class WondersApp extends StatelessWidget with GetItMixin {
       routeInformationParser: appRouter.routeInformationParser,
       locale: locale == null ? null : Locale(locale),
       debugShowCheckedModeBanner: false,
+      builder: (context, child) {
+        return WondersAppScaffold(child: child!);
+      },
       routerDelegate: appRouter.routerDelegate,
       theme: ThemeData(fontFamily: $styles.text.body.fontFamily),
       localizationsDelegates: const [

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/cupertino.dart';
 import 'package:wonders/common_libs.dart';
 import 'package:wonders/ui/common/modals//fullscreen_video_viewer.dart';
@@ -32,7 +34,6 @@ class ScreenPaths {
 /// Routing table, matches string paths to UI Screens, optionally parses params from the paths
 final appRouter = GoRouter(
   redirect: _handleRedirect,
-  navigatorBuilder: (_, __, child) => WondersAppScaffold(child: child),
   routes: [
     AppRoute(ScreenPaths.splash, (_) => Container(color: $styles.colors.greyStrong)), // This will be hidden
     AppRoute(ScreenPaths.home, (_) => HomeScreen()),
@@ -98,7 +99,8 @@ class AppRoute extends GoRoute {
   final bool useFade;
 }
 
-String? _handleRedirect(GoRouterState state) {
+FutureOr<String?> _handleRedirect(
+    BuildContext _, GoRouterState state) {
   // Prevent anyone from navigating away from `/` if app is starting up.
   if (!appLogic.isBootstrapComplete && state.location != ScreenPaths.splash) {
     return ScreenPaths.splash;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -125,10 +125,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -428,10 +428,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: aec1999abe8b2f131eda46d4c9629048fb1befed2b65e90b73f9193a300ce489
+      sha256: "6d1607d76bb3a6ef52947ddae870948b9fd5bc7a5d1ef992ec4bed2fc2006fc3"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.1"
+    version: "5.2.4"
   google_maps:
     dependency: transitive
     description:
@@ -636,18 +636,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "586678f20e112219ed0f73215f01bcdf1d769824ba2ebae45ad918a9bfde9bdb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.3.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "12307e7f0605ce3da64cf0db90e5fcab0869f3ca03f76be6bb2991ce0a55e82b"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   mime:
     dependency: transitive
     description:
@@ -1270,5 +1270,5 @@ packages:
     source: hosted
     version: "2.0.2"
 sdks:
-  dart: ">=2.19.0 <4.0.0"
+  dart: ">=3.0.0-0 <4.0.0"
   flutter: ">=3.7.0-0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   get_it_mixin: ^3.1.4
   google_maps_flutter: ^2.2.3
   google_maps_flutter_web: ^0.4.0+5
-  go_router: ^4.2.8
+  go_router: ^5.1.2
   http: ^0.13.5
   image_fade: ^0.6.2
   image_gallery_saver: ^1.7.1


### PR DESCRIPTION
Upgrading `go_router` was necessary to execute the app on `Flutter (Channel main, 3.10.0-7.0.pre.3, on macOS 13.2.1 22D68 darwin-arm64, locale en)`.  I'm not sure if this breaks it's usage with older versions of flutter that you want to maintain?