### PR TITLE
Removed yellow lines under the suggestion title and item text

### DIFF
--- a/lib/ui/screens/artifact/artifact_search/widgets/_search_input.dart
+++ b/lib/ui/screens/artifact/artifact_search/widgets/_search_input.dart
@@ -83,11 +83,13 @@ class _SearchInput extends StatelessWidget {
       margin: EdgeInsets.only(bottom: $styles.insets.xxs),
       decoration: BoxDecoration(border: Border(bottom: BorderSide(color: $styles.colors.greyStrong.withOpacity(0.1)))),
       child: CenterLeft(
-        child: Text(
-          $strings.searchInputTitleSuggestions.toUpperCase(),
-          overflow: TextOverflow.ellipsis,
-          textHeightBehavior: TextHeightBehavior(applyHeightToFirstAscent: false),
+        child: DefaultTextStyle(
           style: $styles.text.title2.copyWith(color: $styles.colors.black),
+          child: Text(
+            $strings.searchInputTitleSuggestions.toUpperCase(),
+            overflow: TextOverflow.ellipsis,
+            textHeightBehavior: TextHeightBehavior(applyHeightToFirstAscent: false),
+          ),
         ),
       ),
     );
@@ -100,11 +102,13 @@ class _SearchInput extends StatelessWidget {
       child: Padding(
         padding: EdgeInsets.all($styles.insets.xs),
         child: CenterLeft(
-          child: Text(
-            suggestion,
-            overflow: TextOverflow.ellipsis,
-            textHeightBehavior: TextHeightBehavior(applyHeightToFirstAscent: false),
+          child: DefaultTextStyle(
             style: $styles.text.bodySmall.copyWith(color: $styles.colors.greyStrong),
+            child: Text(
+              suggestion,
+              overflow: TextOverflow.ellipsis,
+              textHeightBehavior: TextHeightBehavior(applyHeightToFirstAscent: false),
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
### Here's what we had previously:
![old view](https://github.com/gskinnerTeam/flutter-wonderous-app/assets/56723384/81984035-b9a8-48e6-b3ca-a8932c2896a3)

### So after wrapping the suggestion title and items text inside the `DefaultTextStyle` widget we've got this:
![new preview](https://github.com/gskinnerTeam/flutter-wonderous-app/assets/56723384/f6cd9bc0-f67d-4501-a545-758ea98a66b7)
