### PR TITLE
fix: dispose swipeController

### DIFF
--- a/lib/ui/screens/home/_vertical_swipe_controller.dart
+++ b/lib/ui/screens/home/_vertical_swipe_controller.dart
@@ -61,4 +61,10 @@ class _VerticalSwipeController {
       onVerticalDragCancel: handleVerticalSwipeCancelled,
       behavior: HitTestBehavior.translucent,
       child: child);
+
+  void dispose(){
+    swipeAmt.dispose();
+    isPointerDown.dispose();
+    swipeReleaseAnim.dispose();
+  }
 }

--- a/lib/ui/screens/home/wonders_home_screen.dart
+++ b/lib/ui/screens/home/wonders_home_screen.dart
@@ -138,6 +138,12 @@ class _HomeScreenState extends State<HomeScreen> with SingleTickerProviderStateM
     ));
   }
 
+  @override
+  void dispose() {
+    _swipeController.dispose();
+    super.dispose();
+  }
+
   Widget _buildMgPageView() {
     return ExcludeSemantics(
       child: PageView.builder(


### PR DESCRIPTION
Dispose any instance of ValueNotifier from swipeController to avoid memory leaks. dispose method of ValueNotifier would remove all listeners.

Dispose swipeReleaseAnim to avoid memory leaks.

```
/// lib/ui/screens/home/_vertical_swipe_controller.dart
  void dispose(){
    swipeAmt.dispose();
    isPointerDown.dispose();
    swipeReleaseAnim.dispose();
  }
```

```
/// lib/ui/screens/home/wonders_home_screen.dart
  @override
  void dispose() {
    _swipeController.dispose();
    super.dispose();
  }
```