### PR TITLE
Switch back to hosted version of `package:gap`

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -395,12 +395,11 @@ packages:
   gap:
     dependency: "direct main"
     description:
-      path: "."
-      ref: dc980bf
-      resolved-ref: dc980bf4482ec5b8378aeb4c72e4face105c5d72
-      url: "https://github.com/esDotDev/gap.git"
-    source: git
-    version: "3.0.1+1"
+      name: gap
+      sha256: f19387d4e32f849394758b91377f9153a1b41d79513ef7668c088c77dbc6955d
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   get_it:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,10 +25,7 @@ dependencies:
   flutter_native_splash: ^2.2.17
   flutter_staggered_grid_view: ^0.6.2
   flutter_svg: ^2.0.1
-  gap:
-    git:
-      url: https://github.com/esDotDev/gap.git
-      ref: dc980bf
+  gap: ^3.0.1
   get_it: ^7.2.0
   get_it_mixin: ^3.1.4
   google_maps_flutter: ^2.2.3


### PR DESCRIPTION
It was switched to a custom version in https://github.com/gskinnerTeam/flutter-wonderous-app/commit/e30e2ebf48b99ef3f0324153205d5ca1c5467c07 due to an issue with the pre-release channels. This has been fixed in the latest `package:gap` release: https://pub.dev/packages/gap/changelog#301