### PR TITLE
Fixes language switch button being partially unclickable

### DIFF
--- a/lib/ui/screens/home_menu/home_menu.dart
+++ b/lib/ui/screens/home_menu/home_menu.dart
@@ -61,12 +61,6 @@ class _HomeMenuState extends State<HomeMenu> {
 
         PopNavigatorUnderlay(),
 
-        AppHeader(
-          isTransparent: true,
-          backIcon: AppIcons.close,
-          trailing: (_) => LocaleSwitcher(),
-        ),
-
         /// Content
         SafeArea(
           child: Center(
@@ -89,6 +83,12 @@ class _HomeMenuState extends State<HomeMenu> {
               ),
             ),
           ),
+        ),
+
+        AppHeader(
+          isTransparent: true,
+          backIcon: AppIcons.close,
+          trailing: (_) => LocaleSwitcher(),
         ),
       ],
     );


### PR DESCRIPTION
ExpandedScrollingColumn is on top of the AppHeader and blocks presses on the left half of the language switch button. This commit moves the AppHeader to the top of the stack.

#104 