### PR TITLE
Fix throttler calling an action twice

### DIFF
--- a/lib/logic/common/throttler.dart
+++ b/lib/logic/common/throttler.dart
@@ -25,6 +25,7 @@ class Throttler {
 
   void _callAction() {
     _action?.call(); // If we have an action queued up, complete it.
+    _action = null; // Once an action is called, do not call the same action again unless another action is queued.
     _timer = null;
   }
 


### PR DESCRIPTION
There is a bug in throttler where an action is called immediately and also again when the Timer expires despite only being scheduled once by call(). This commit resets the action to null once it is completed to prevent the action to be called again. 