### PR TITLE
Minor fix on the operator check

### DIFF
--- a/lib/logic/common/retry_image.dart
+++ b/lib/logic/common/retry_image.dart
@@ -90,7 +90,7 @@ class RetryImage extends ImageProvider<Object> {
     if (other.runtimeType != runtimeType) {
       return false;
     }
-    return other is RetryImage && other.imageProvider == other.imageProvider && other.scale == scale;
+    return other is RetryImage && other.imageProvider == imageProvider && other.scale == scale;
   }
 
   @override


### PR DESCRIPTION
Made minor change on the `==` operator to validate if the compared `Object` `imageProvider` matches the current `Object`.