### PR TITLE
Replace outdated dependencies, with gskinner updated one's, and overrides intl dependency.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,10 @@ dependencies:
 
   collection: ^1.17.0
   desktop_window: ^0.4.0
-  drop_cap_text: ^1.1.3
+  #drop_cap_text: ^1.1.3
+  drop_cap_text:
+    git:
+      https://github.com/gskinnerTeam/drop_cap_text.git
   equatable: ^2.0.5
   extra_alignments: ^1.0.0+1
   flextras: ^1.0.0
@@ -31,13 +34,14 @@ dependencies:
   google_maps_flutter: ^2.5.3
   google_maps_flutter_web: ^0.5.4+3
   go_router: ^13.0.1
-  home_widget: ^0.4.1 # use the forked version when on `main` flutter branch
-#    git:
-#      url: https://github.com/gskinnerTeam/flutter_home_widget_fork.git
+#  home_widget: ^0.4.1 # use the forked version when on `main` flutter branch
+  home_widget:
+    git:
+      url: https://github.com/gskinnerTeam/flutter_home_widget_fork.git
   http: ^1.1.0
   image: ^4.1.3
   image_fade: ^0.6.2
-  intl: ^0.18.1
+  intl: 0.19.0
   internet_connection_checker: ^1.0.0+1
   package_info_plus: ^5.0.0
   particle_field: ^1.0.0
@@ -52,6 +56,9 @@ dependencies:
   url_launcher: ^6.1.14
   webview_flutter: ^4.0.2
   youtube_player_iframe: ^4.0.4
+
+dependency_overrides:
+  intl: ^0.18.1
 
 dev_dependencies:
   icons_launcher: ^2.1.3


### PR DESCRIPTION
In the last Flutter release, intl version 0.19.0 is pinned, so the easiest solution to continue to use the 0.18.1 version for this repo, is to override it's dependency.

And drop_cap_text, home_widget dependencies are outdated, so it can be replaced with gskinner one's.

