### PR TITLE
Fix issue #175

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,38 +1,10 @@
-def localProperties = new Properties()
-def localPropertiesFile = rootProject.file('local.properties')
-if (localPropertiesFile.exists()) {
-    localPropertiesFile.withReader('UTF-8') { reader ->
-        localProperties.load(reader)
-    }
-}
-
-def flutterRoot = localProperties.getProperty('flutter.sdk')
-if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
-}
-
-def keystoreProperties = new Properties()
-def keystorePropertiesFile = rootProject.file('key.properties')
-if (keystorePropertiesFile.exists()) {
-    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
-
-}
-
-def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
-if (flutterVersionCode == null) {
-    flutterVersionCode = '1'
-}
-
-def flutterVersionName = localProperties.getProperty('flutter.versionName')
-if (flutterVersionName == null) {
-    flutterVersionName = '1.0'
-}
-
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
-
+plugins { 
+    id 'com.android.application' 
+    id 'kotlin-android' 
+    id "dev.flutter.flutter-gradle-plugin"
+ }
 android {
+    namespace 'com.gskinner.flutter.wonders'
     compileSdkVersion 34
 
     defaultConfig {
@@ -43,8 +15,8 @@ android {
         minSdkVersion 23
         targetSdkVersion flutter.targetSdkVersion
         multiDexEnabled true
-        versionCode flutterVersionCode.toInteger()
-        versionName flutterVersionName
+        versionCode 9
+        versionName "2.2.2"
     }
 
    buildTypes {
@@ -77,6 +49,31 @@ flutter {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.google.android.gms:play-services-maps:$maps_version"
+    implementation "com.google.android.gms:play-services-maps:18.2.0"
 }
+
+def localProperties = new Properties()
+def localPropertiesFile = rootProject.file('local.properties')
+if (localPropertiesFile.exists()) {
+    localPropertiesFile.withReader('UTF-8') { reader ->
+        localProperties.load(reader)
+    }
+}
+
+def keystoreProperties = new Properties()
+def keystorePropertiesFile = rootProject.file('key.properties')
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+
+}
+
+def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
+if (flutterVersionCode == null) {
+    flutterVersionCode = '1'
+}
+
+def flutterVersionName = localProperties.getProperty('flutter.versionName')
+if (flutterVersionName == null) {
+    flutterVersionName = '1.0'
+}
+

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,18 +1,3 @@
-buildscript {
-    ext.kotlin_version = '1.9.10'
-    ext.maps_version = '18.1.0'
-
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
 allprojects {
     repositories {
         google()

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,5 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
+# change to gradle 8.0 or higher
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,11 +1,27 @@
-include ':app'
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty("flutter.sdk")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        return flutterSdkPath
+    }()
 
-def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
-def properties = new Properties()
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 
-assert localPropertiesFile.exists()
-localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
 
-def flutterSdkPath = properties.getProperty("flutter.sdk")
-assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
-apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+// remove line:apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+// due to Deprecated imperative apply of Flutter's Gradle plugins see here: https://docs.flutter.dev/release/breaking-changes/flutter-gradle-plugin-apply
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "7.3.0" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.10" apply false
+}
+
+include ":app"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,8 +35,8 @@ dependencies:
   google_maps_flutter: ^2.9.0
   go_router: ^14.2.8
   home_widget: ^0.7.0 # use the forked version when on `main` flutter branch
-#    git:
-#      url: https://github.com/gskinnerTeam/flutter_home_widget_fork.git
+  #    git:
+  #      url: https://github.com/gskinnerTeam/flutter_home_widget_fork.git
   http: ^1.1.0
   image: ^4.1.3
   image_fade: ^0.6.2


### PR DESCRIPTION
Hi there! I just fixed issue #175 ; **Gradle Build Failure and Deprecated Plugin Usage in Wonderous**.  On the issue note, it says it was tried on Flutter master 3.21.0-12.0.pre.6 or stable 3.19.5 but I also got the same issue on my own newer Flutter 3.24.2 • channel stable. I fixed it by migrating from the depreciated (since Flutter 3.16) way of applying the flutter Gradle plugin to now using the plugins block in 'settings.gradle' file

see more details here:  https://docs.flutter.dev/release/breaking-changes/flutter-gradle-plugin-apply