### PR TITLE
Youtube Player - Updated deprecated keyboard listener and added WASM status display in Console.

### DIFF
--- a/lib/logic/app_logic.dart
+++ b/lib/logic/app_logic.dart
@@ -4,6 +4,7 @@ import 'dart:ui';
 import 'package:desktop_window/desktop_window.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_displaymode/flutter_displaymode.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:wonders/common_libs.dart';
 import 'package:wonders/logic/common/platform_info.dart';
 import 'package:wonders/ui/common/modals/fullscreen_video_viewer.dart';
@@ -42,9 +43,13 @@ class AppLogic {
 
     if (kIsWeb) {
       // SB: This is intentionally not a debugPrint, as it's a message for users who open the console on web.
+          // Display if running in WASM mode.
+      const isRunningWithWasm = bool.fromEnvironment('dart.tool.dart2wasm');
+      PackageInfo packageInfo = await PackageInfo.fromPlatform();
       print(
         '''Thanks for checking out Wonderous on the web!
-        If you encounter any issues please report them at https://github.com/gskinnerTeam/flutter-wonderous-app/issues.''',
+        If you encounter any issues please report them at https://github.com/gskinnerTeam/flutter-wonderous-app/issues.
+        Version: ${packageInfo.version}  -  WASM-enabled: $isRunningWithWasm''',
       );
       // Required on web to automatically enable accessibility features
       WidgetsFlutterBinding.ensureInitialized().ensureSemantics();

--- a/lib/logic/app_logic.dart
+++ b/lib/logic/app_logic.dart
@@ -43,7 +43,7 @@ class AppLogic {
 
     if (kIsWeb) {
       // SB: This is intentionally not a debugPrint, as it's a message for users who open the console on web.
-          // Display if running in WASM mode.
+      // Display if running in WASM mode.
       const isRunningWithWasm = bool.fromEnvironment('dart.tool.dart2wasm');
       PackageInfo packageInfo = await PackageInfo.fromPlatform();
       print(

--- a/lib/logic/app_logic.dart
+++ b/lib/logic/app_logic.dart
@@ -7,6 +7,7 @@ import 'package:flutter_displaymode/flutter_displaymode.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:wonders/common_libs.dart';
 import 'package:wonders/logic/common/platform_info.dart';
+import 'package:wonders/logic/common/web_wasm_info.dart';
 import 'package:wonders/ui/common/modals/fullscreen_video_viewer.dart';
 import 'package:wonders/ui/common/utils/page_routes.dart';
 
@@ -44,7 +45,8 @@ class AppLogic {
     if (kIsWeb) {
       // SB: This is intentionally not a debugPrint, as it's a message for users who open the console on web.
       // Display if running in WASM mode.
-      const isRunningWithWasm = bool.fromEnvironment('dart.tool.dart2wasm');
+      const isCompiledWithWasm = bool.fromEnvironment('dart.tool.dart2wasm');
+      final isRunningWithWasm = isCompiledWithWasm || isWasmOptInFromBootstrap;
       PackageInfo packageInfo = await PackageInfo.fromPlatform();
       print(
         '''Thanks for checking out Wonderous on the web!

--- a/lib/logic/common/web_wasm_info.dart
+++ b/lib/logic/common/web_wasm_info.dart
@@ -1,0 +1,5 @@
+import 'package:wonders/logic/common/web_wasm_info_stub.dart'
+    if (dart.library.html) 'package:wonders/logic/common/web_wasm_info_web.dart'
+    as impl;
+
+bool get isWasmOptInFromBootstrap => impl.isWasmOptInFromBootstrap;

--- a/lib/logic/common/web_wasm_info_stub.dart
+++ b/lib/logic/common/web_wasm_info_stub.dart
@@ -1,0 +1,1 @@
+bool get isWasmOptInFromBootstrap => false;

--- a/lib/logic/common/web_wasm_info_web.dart
+++ b/lib/logic/common/web_wasm_info_web.dart
@@ -1,0 +1,20 @@
+import 'dart:html' as html;
+
+bool get isWasmOptInFromBootstrap {
+  final params = Uri.base.queryParameters;
+  final wasm = params['wasm'];
+  final hasWasmParam = params.containsKey('wasm');
+  final wasmParam = (wasm ?? '').toLowerCase();
+  final explicitWasmSetting = wasmParam == '1' || wasmParam == 'true';
+
+  final ua = html.window.navigator.userAgent.toLowerCase();
+  final vendor = html.window.navigator.vendor.toLowerCase();
+  final isFirefox = RegExp(r'firefox/\d+', caseSensitive: false).hasMatch(ua);
+  final isSafari =
+      RegExp(r'safari/\d+', caseSensitive: false).hasMatch(ua) &&
+      vendor.contains('apple') &&
+      !RegExp(r'chrome|crios|edg|opr|fxios|android', caseSensitive: false).hasMatch(ua);
+
+  final defaultWasmSetting = !(isFirefox || isSafari);
+  return hasWasmParam ? explicitWasmSetting : defaultWasmSetting;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,6 +19,7 @@ void main() async {
   if (!kIsWeb) {
     FlutterNativeSplash.preserve(widgetsBinding: widgetsBinding);
   }
+
   GoRouter.optionURLReflectsImperativeAPIs = true;
 
   // Start app

--- a/lib/ui/common/modals/fullscreen_video_viewer.dart
+++ b/lib/ui/common/modals/fullscreen_video_viewer.dart
@@ -62,14 +62,7 @@ class _FullscreenVideoViewerState extends State<FullscreenVideoViewer> {
       backgroundColor: Colors.black,
       body: Stack(
         children: [
-          Center(
-            child: (PlatformInfo.isMobile || kIsWeb)
-                ? YoutubePlayer(
-                    controller: _controller,
-                    aspectRatio: aspect,
-                  )
-                : Placeholder(),
-          ),
+          Text('Oops, nothing here!'),
           SafeArea(
             child: Padding(
               padding: EdgeInsets.all($styles.insets.md),

--- a/lib/ui/common/modals/fullscreen_video_viewer.dart
+++ b/lib/ui/common/modals/fullscreen_video_viewer.dart
@@ -26,7 +26,11 @@ class _FullscreenVideoViewerState extends State<FullscreenVideoViewer> {
   void initState() {
     super.initState();
     appLogic.supportedOrientationsOverride = [Axis.horizontal, Axis.vertical];
-    _controller.cueVideoByUrl(mediaContentUrl: 'https://www.youtube.com/v/${widget.id}');
+    try {
+      _controller.cueVideoByUrl(mediaContentUrl: 'https://www.youtube.com/v/${widget.id}');
+    } catch (e) {
+      debugPrint('VP Error: $e');
+    }
     RawKeyboard.instance.addListener(_handleKeyDown);
   }
 
@@ -35,6 +39,7 @@ class _FullscreenVideoViewerState extends State<FullscreenVideoViewer> {
     // when view closes, remove the override
     appLogic.supportedOrientationsOverride = null;
     RawKeyboard.instance.removeListener(_handleKeyDown);
+    _controller.close();
     super.dispose();
   }
 
@@ -62,7 +67,14 @@ class _FullscreenVideoViewerState extends State<FullscreenVideoViewer> {
       backgroundColor: Colors.black,
       body: Stack(
         children: [
-          Text('Oops, nothing here!'),
+          Center(
+            child: (PlatformInfo.isMobile || kIsWeb)
+              ? YoutubePlayer(
+                  controller: _controller,
+                  aspectRatio: aspect,
+                )
+              : Placeholder(),
+          ),
           SafeArea(
             child: Padding(
               padding: EdgeInsets.all($styles.insets.md),

--- a/lib/ui/common/modals/fullscreen_video_viewer.dart
+++ b/lib/ui/common/modals/fullscreen_video_viewer.dart
@@ -25,7 +25,7 @@ class _FullscreenVideoViewerState extends State<FullscreenVideoViewer> {
     _controller = YoutubePlayerController(
       key: 'youtube-player',
       params: const YoutubePlayerParams(
-        origin: 'https://www.youtube-nocookie.com',
+        privacyEnhancedMode: true,
         enableCaption: true,
       ),
     );
@@ -49,7 +49,8 @@ class _FullscreenVideoViewerState extends State<FullscreenVideoViewer> {
   }
 
   bool onKeyDownEvent(KeyDownEvent event) {
-    if (event.logicalKey == LogicalKeyboardKey.space || event.logicalKey == LogicalKeyboardKey.enter && _enableVideo) {
+    if ((event.logicalKey == LogicalKeyboardKey.space || event.logicalKey == LogicalKeyboardKey.enter) &&
+        _enableVideo) {
       _handleKeyDown(event).ignore();
       return true;
     }
@@ -70,28 +71,33 @@ class _FullscreenVideoViewerState extends State<FullscreenVideoViewer> {
   Widget build(BuildContext context) {
     double aspect = context.isLandscape ? MediaQuery.of(context).size.aspectRatio : (16 / 9);
 
-    return YoutubePlayerScaffold(
-      backgroundColor: Colors.black,
+    return YoutubePlayerControllerProvider(
       controller: _controller,
-      aspectRatio: aspect,
-      builder: (context, player) => Stack(
-        children: [
-          FullscreenKeyboardListener(
-            onKeyDown: onKeyDownEvent,
-            child: Center(
-              child: (PlatformInfo.isMobile || kIsWeb) ? player : Placeholder(),
-            ),
-          ),
-          SafeArea(
-            child: Padding(
-              padding: EdgeInsets.all($styles.insets.md),
-              // Wrap btn in a PointerInterceptor to prevent the HTML video player from intercepting the pointer (https://pub.dev/packages/pointer_interceptor)
-              child: PointerInterceptor(
-                child: const BackBtn(),
+      child: Container(
+        color: Colors.black,
+        child: Stack(
+          children: [
+            FullscreenKeyboardListener(
+              onKeyDown: onKeyDownEvent,
+              child: Center(
+                child: (PlatformInfo.isMobile || kIsWeb)
+                    ? YoutubePlayer(
+                        controller: _controller,
+                        aspectRatio: aspect,
+                      )
+                    : Placeholder(),
               ),
             ),
-          ),
-        ],
+            SafeArea(
+              child: Padding(
+                padding: EdgeInsets.all($styles.insets.md),
+                child: PointerInterceptor(
+                  child: const BackBtn(),
+                ),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/ui/common/modals/fullscreen_video_viewer.dart
+++ b/lib/ui/common/modals/fullscreen_video_viewer.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:pointer_interceptor/pointer_interceptor.dart';
 import 'package:wonders/common_libs.dart';
 import 'package:wonders/logic/common/platform_info.dart';
+import 'package:wonders/ui/common/fullscreen_keyboard_listener.dart';
 import 'package:youtube_player_iframe/youtube_player_iframe.dart';
 
 class FullscreenVideoViewer extends StatefulWidget {
@@ -15,18 +16,16 @@ class FullscreenVideoViewer extends StatefulWidget {
 class _FullscreenVideoViewerState extends State<FullscreenVideoViewer> {
   late YoutubePlayerController _controller;
 
-  bool get _enableVideo => PlatformInfo.isMobile;
+  bool get _enableVideo => PlatformInfo.isMobile || kIsWeb;
 
   @override
   void initState() {
     appLogic.supportedOrientationsOverride = [Axis.horizontal, Axis.vertical];
-    HardwareKeyboard.instance.addHandler(onKeyEvent);
-
     _controller = YoutubePlayerController(
       key: 'youtube-player',
       params: const YoutubePlayerParams(
         origin: 'https://www.youtube-nocookie.com',
-        enableCaption: false
+        enableCaption: false,
       ),
     );
     WidgetsBinding.instance.addPostFrameCallback((_) => loadPlayer());
@@ -45,7 +44,6 @@ class _FullscreenVideoViewerState extends State<FullscreenVideoViewer> {
   void dispose() {
     // when view closes, remove the override
     appLogic.supportedOrientationsOverride = null;
-    HardwareKeyboard.instance.removeHandler(onKeyEvent);
     _controller.close();
     super.dispose();
   }
@@ -87,8 +85,11 @@ class _FullscreenVideoViewerState extends State<FullscreenVideoViewer> {
       aspectRatio: aspect,
       builder:(context, player) => Stack(
         children: [
-          Center(
-            child: (PlatformInfo.isMobile || kIsWeb) ? player : Placeholder(),
+          FullscreenKeyboardListener(
+            onKeyDown: onKeyEvent,
+            child: Center(
+              child: (PlatformInfo.isMobile || kIsWeb) ? player : Placeholder(),
+            ),
           ),
           SafeArea(
             child: Padding(

--- a/lib/ui/common/modals/fullscreen_video_viewer.dart
+++ b/lib/ui/common/modals/fullscreen_video_viewer.dart
@@ -13,39 +13,51 @@ class FullscreenVideoViewer extends StatefulWidget {
 }
 
 class _FullscreenVideoViewerState extends State<FullscreenVideoViewer> {
-  late final _controller = YoutubePlayerController(
-    params: const YoutubePlayerParams(
-      origin: 'https://www.youtube-nocookie.com',
-      enableCaption: true
-    ),
-  );
+  late YoutubePlayerController _controller;
 
   bool get _enableVideo => PlatformInfo.isMobile;
 
   @override
   void initState() {
-    super.initState();
     appLogic.supportedOrientationsOverride = [Axis.horizontal, Axis.vertical];
+    HardwareKeyboard.instance.addHandler(onKeyEvent);
+
+    _controller = YoutubePlayerController(
+      key: 'youtube-player',
+      params: const YoutubePlayerParams(
+        origin: 'https://www.youtube-nocookie.com',
+        enableCaption: false
+      ),
+    );
+    WidgetsBinding.instance.addPostFrameCallback((_) => loadPlayer());
+    super.initState();
+  }
+
+  void loadPlayer() {
     try {
-      _controller.cueVideoByUrl(mediaContentUrl: 'https://www.youtube.com/v/${widget.id}');
+      _controller.cueVideoByUrl(mediaContentUrl: 'https://www.youtube-nocookie.com/v/${widget.id}');
     } catch (e) {
       debugPrint('VP Error: $e');
     }
-    RawKeyboard.instance.addListener(_handleKeyDown);
   }
 
   @override
   void dispose() {
     // when view closes, remove the override
     appLogic.supportedOrientationsOverride = null;
-    RawKeyboard.instance.removeListener(_handleKeyDown);
+    HardwareKeyboard.instance.removeHandler(onKeyEvent);
     _controller.close();
     super.dispose();
   }
 
-  Future<void> _handleKeyDown(RawKeyEvent value) async {
-    if (value.repeat) return;
-    if (value is RawKeyDownEvent) {
+  bool onKeyEvent(KeyEvent event) {
+    _handleKeyDown(event);
+    return true;
+  }
+
+  Future<KeyEventResult> _handleKeyDown(KeyEvent value) async {
+    if (value is KeyRepeatEvent) return KeyEventResult.ignored;
+    if (value is KeyDownEvent) {
       final k = value.logicalKey;
       if (k == LogicalKeyboardKey.enter || k == LogicalKeyboardKey.space) {
         if (_enableVideo) {
@@ -58,22 +70,25 @@ class _FullscreenVideoViewerState extends State<FullscreenVideoViewer> {
         }
       }
     }
+    return KeyEventResult.handled;
   }
 
   @override
   Widget build(BuildContext context) {
     double aspect = context.isLandscape ? MediaQuery.of(context).size.aspectRatio : 9 / 9;
-    return Scaffold(
+
+    PlatformDispatcher.instance.onError = (error, stack) {
+      return true;
+    };
+    
+    return YoutubePlayerScaffold(
       backgroundColor: Colors.black,
-      body: Stack(
+      controller: _controller,
+      aspectRatio: aspect,
+      builder:(context, player) => Stack(
         children: [
           Center(
-            child: (PlatformInfo.isMobile || kIsWeb)
-              ? YoutubePlayer(
-                  controller: _controller,
-                  aspectRatio: aspect,
-                )
-              : Placeholder(),
+            child: (PlatformInfo.isMobile || kIsWeb) ? player : Placeholder(),
           ),
           SafeArea(
             child: Padding(

--- a/lib/ui/common/modals/fullscreen_video_viewer.dart
+++ b/lib/ui/common/modals/fullscreen_video_viewer.dart
@@ -49,21 +49,19 @@ class _FullscreenVideoViewerState extends State<FullscreenVideoViewer> {
   }
 
   bool onKeyDownEvent(KeyDownEvent event) {
-    _handleKeyDown(event).ignore();
-    return true;
+    if (event.logicalKey == LogicalKeyboardKey.space || event.logicalKey == LogicalKeyboardKey.enter && _enableVideo) {
+      _handleKeyDown(event).ignore();
+      return true;
+    }
+    return false;
   }
 
   Future<KeyEventResult> _handleKeyDown(KeyDownEvent value) async {
-    final k = value.logicalKey;
-    if (k == LogicalKeyboardKey.enter || k == LogicalKeyboardKey.space) {
-      if (_enableVideo) {
-        final state = await _controller.playerState;
-        if (state == PlayerState.playing) {
-          _controller.pauseVideo();
-        } else {
-          _controller.playVideo();
-        }
-      }
+    final state = await _controller.playerState;
+    if (state == PlayerState.playing) {
+      _controller.pauseVideo();
+    } else {
+      _controller.playVideo();
     }
     return KeyEventResult.handled;
   }

--- a/lib/ui/common/modals/fullscreen_video_viewer.dart
+++ b/lib/ui/common/modals/fullscreen_video_viewer.dart
@@ -48,23 +48,20 @@ class _FullscreenVideoViewerState extends State<FullscreenVideoViewer> {
     super.dispose();
   }
 
-  bool onKeyEvent(KeyEvent event) {
-    _handleKeyDown(event);
+  bool onKeyDownEvent(KeyDownEvent event) {
+    _handleKeyDown(event).ignore();
     return true;
   }
 
-  Future<KeyEventResult> _handleKeyDown(KeyEvent value) async {
-    if (value is KeyRepeatEvent) return KeyEventResult.ignored;
-    if (value is KeyDownEvent) {
-      final k = value.logicalKey;
-      if (k == LogicalKeyboardKey.enter || k == LogicalKeyboardKey.space) {
-        if (_enableVideo) {
-          final state = await _controller.playerState;
-          if (state == PlayerState.playing) {
-            _controller.pauseVideo();
-          } else {
-            _controller.playVideo();
-          }
+  Future<KeyEventResult> _handleKeyDown(KeyDownEvent value) async {
+    final k = value.logicalKey;
+    if (k == LogicalKeyboardKey.enter || k == LogicalKeyboardKey.space) {
+      if (_enableVideo) {
+        final state = await _controller.playerState;
+        if (state == PlayerState.playing) {
+          _controller.pauseVideo();
+        } else {
+          _controller.playVideo();
         }
       }
     }
@@ -73,11 +70,7 @@ class _FullscreenVideoViewerState extends State<FullscreenVideoViewer> {
 
   @override
   Widget build(BuildContext context) {
-    double aspect = context.isLandscape ? MediaQuery.of(context).size.aspectRatio : 9 / 9;
-
-    PlatformDispatcher.instance.onError = (error, stack) {
-      return true;
-    };
+    double aspect = context.isLandscape ? MediaQuery.of(context).size.aspectRatio : (16 / 9);
 
     return YoutubePlayerScaffold(
       backgroundColor: Colors.black,
@@ -86,7 +79,7 @@ class _FullscreenVideoViewerState extends State<FullscreenVideoViewer> {
       builder: (context, player) => Stack(
         children: [
           FullscreenKeyboardListener(
-            onKeyDown: onKeyEvent,
+            onKeyDown: onKeyDownEvent,
             child: Center(
               child: (PlatformInfo.isMobile || kIsWeb) ? player : Placeholder(),
             ),

--- a/lib/ui/common/modals/fullscreen_video_viewer.dart
+++ b/lib/ui/common/modals/fullscreen_video_viewer.dart
@@ -20,16 +20,16 @@ class _FullscreenVideoViewerState extends State<FullscreenVideoViewer> {
 
   @override
   void initState() {
+    super.initState();
     appLogic.supportedOrientationsOverride = [Axis.horizontal, Axis.vertical];
     _controller = YoutubePlayerController(
       key: 'youtube-player',
       params: const YoutubePlayerParams(
         origin: 'https://www.youtube-nocookie.com',
-        enableCaption: false,
+        enableCaption: true,
       ),
     );
     WidgetsBinding.instance.addPostFrameCallback((_) => loadPlayer());
-    super.initState();
   }
 
   void loadPlayer() {
@@ -78,12 +78,12 @@ class _FullscreenVideoViewerState extends State<FullscreenVideoViewer> {
     PlatformDispatcher.instance.onError = (error, stack) {
       return true;
     };
-    
+
     return YoutubePlayerScaffold(
       backgroundColor: Colors.black,
       controller: _controller,
       aspectRatio: aspect,
-      builder:(context, player) => Stack(
+      builder: (context, player) => Stack(
         children: [
           FullscreenKeyboardListener(
             onKeyDown: onKeyEvent,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1018,26 +1018,26 @@ packages:
     dependency: transitive
     description:
       name: webview_flutter_android
-      sha256: "2a03df01df2fd30b075d1e7f24c28aee593f2e5d5ac4c3c4283c5eda63717b24"
+      sha256: ad5182eff9a550925330cb9f0cb038eddfdd5712aba8b77aa0f0400e50f6e688
       url: "https://pub.dev"
     source: hosted
-    version: "4.10.13"
+    version: "4.12.0"
   webview_flutter_platform_interface:
     dependency: transitive
     description:
       name: webview_flutter_platform_interface
-      sha256: "63d26ee3aca7256a83ccb576a50272edd7cfc80573a4305caa98985feb493ee0"
+      sha256: "1221c1b12f5278791042f2ec2841743784cf25c5a644e23d6680e5d718824f04"
       url: "https://pub.dev"
     source: hosted
-    version: "2.14.0"
+    version: "2.15.1"
   webview_flutter_wkwebview:
     dependency: transitive
     description:
       name: webview_flutter_wkwebview
-      sha256: fc0af89d403e1c053f03d023d97550412fa79f35332e2939514c82e6fe633198
+      sha256: "82648217f537573e1ca9ae9952d3eacedca6ab5aee69dc84445fc763766dcea2"
       url: "https://pub.dev"
     source: hosted
-    version: "3.23.8"
+    version: "3.25.1"
   win32:
     dependency: transitive
     description:
@@ -1074,10 +1074,10 @@ packages:
     dependency: "direct main"
     description:
       name: youtube_player_iframe
-      sha256: "6690da91591d14b32a6884eb6ae270ea4cc946a748d577d89d18cde565be689f"
+      sha256: e74ce6a33293fdd0eb0fb25f65935afa8ee33eeb6d89bff69ff9371665af1408
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.2"
+    version: "6.0.0"
   youtube_player_iframe_web:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,7 +55,7 @@ dependencies:
   unsplash_client: ^3.0.0
   url_launcher: ^6.1.14
   webview_flutter: ^4.0.2
-  youtube_player_iframe: ^5.2.2
+  youtube_player_iframe: ^6.0.0
 
 dev_dependencies:
   icons_launcher: ^3.0.0


### PR DESCRIPTION
Initially this started as a memory leak fix for the Youtube player that caused constant, unending errors in the console, but that has been determined to instead have been caused by the React Native Debugger extension on Chrome and is thus a non-issue.

During the exploration, however, I added the ability to check and log WASM status in the console, as well as updated the keyboard event listener for YoutubePlayerIFrame to be consistent with the rest of the app from a deprecated code.

Also updated the Youtube_iframe_player framework to 6.0.0 - Changelog: https://pub.dev/packages/youtube_player_iframe/changelog