### PR TITLE
RenderBox Error Fix

### DIFF
--- a/lib/ui/common/global_coords_builder.dart
+++ b/lib/ui/common/global_coords_builder.dart
@@ -35,7 +35,7 @@ class _GlobalCoordsBuilderState extends State<GlobalCoordsBuilder> {
         } catch (_) {
           return;
         }
-        if (newOffset != null && (_globalOffset != newOffset || _size != box.size)) {
+        if (_globalOffset != newOffset || _size != box.size) {
           setState(() {
             _globalOffset = newOffset;
             _size = box.size;
@@ -54,7 +54,6 @@ class _GlobalCoordsBuilderState extends State<GlobalCoordsBuilder> {
       },
       child: LayoutBuilder(
         builder: (context, constraints) {
-          // Update on layout changes too
           WidgetsBinding.instance.addPostFrameCallback((_) => _updateOffset());
           return Container(
             key: _key,

--- a/lib/ui/common/global_coords_builder.dart
+++ b/lib/ui/common/global_coords_builder.dart
@@ -29,10 +29,13 @@ class _GlobalCoordsBuilderState extends State<GlobalCoordsBuilder> {
     if (context != null) {
       final RenderBox? box = context.findRenderObject() as RenderBox?;
       if (box != null && box.hasSize && mounted) {
-        setState(() {
-          _globalOffset = box.localToGlobal(Offset.zero);
-          _size = box.size;
-        });
+        Offset newOffset = box.localToGlobal(Offset.zero);
+        if (_globalOffset != newOffset || _size != box.size) {
+          setState(() {
+            _globalOffset = newOffset;
+            _size = box.size;
+          });
+        }
       }
     }
   }

--- a/lib/ui/common/global_coords_builder.dart
+++ b/lib/ui/common/global_coords_builder.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/scheduler.dart';
+import 'package:wonders/common_libs.dart';
+
+class GlobalCoordsBuilder extends StatefulWidget {
+  const GlobalCoordsBuilder({
+    super.key,
+    required this.builder,
+  });
+
+  final Widget Function(BuildContext context, Offset? globalOffset, Size? size) builder;
+
+  @override
+  State<GlobalCoordsBuilder> createState() => _GlobalCoordsBuilderState();
+}
+
+class _GlobalCoordsBuilderState extends State<GlobalCoordsBuilder> {
+  final GlobalKey _key = GlobalKey();
+  Offset? _globalOffset;
+  Size? _size;
+
+  @override
+  void initState() {
+    super.initState();
+    SchedulerBinding.instance.addPostFrameCallback((_) => _updateOffset());
+  }
+
+  void _updateOffset() {
+    final context = _key.currentContext;
+    if (context != null) {
+      final RenderBox? box = context.findRenderObject() as RenderBox?;
+      if (box != null && box.hasSize && mounted) {
+        setState(() {
+          _globalOffset = box.localToGlobal(Offset.zero);
+          _size = box.size;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return NotificationListener<SizeChangedLayoutNotification>(
+      onNotification: (_) {
+        _updateOffset();
+        return false;
+      },
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          // Update on layout changes too
+          WidgetsBinding.instance.addPostFrameCallback((_) => _updateOffset());
+          return Container(
+            key: _key,
+            constraints: constraints,
+            child: Builder(
+              builder: (context) => widget.builder(context, _globalOffset, _size),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/ui/common/global_coords_builder.dart
+++ b/lib/ui/common/global_coords_builder.dart
@@ -29,8 +29,13 @@ class _GlobalCoordsBuilderState extends State<GlobalCoordsBuilder> {
     if (context != null) {
       final RenderBox? box = context.findRenderObject() as RenderBox?;
       if (box != null && box.hasSize && mounted) {
-        Offset newOffset = box.localToGlobal(Offset.zero);
-        if (_globalOffset != newOffset || _size != box.size) {
+        Offset? newOffset;
+        try {
+          newOffset = box.localToGlobal(Offset.zero);
+        } catch (_) {
+          return;
+        }
+        if (newOffset != null && (_globalOffset != newOffset || _size != box.size)) {
           setState(() {
             _globalOffset = newOffset;
             _size = box.size;

--- a/lib/ui/common/scaling_list_item.dart
+++ b/lib/ui/common/scaling_list_item.dart
@@ -1,6 +1,5 @@
 import 'package:wonders/common_libs.dart';
 import 'package:wonders/ui/common/global_coords_builder.dart';
-import 'package:wonders/ui/common/utils/context_utils.dart';
 
 class AnimatedListItem extends StatelessWidget {
   const AnimatedListItem({super.key, required this.scrollPos, required this.builder});

--- a/lib/ui/common/scaling_list_item.dart
+++ b/lib/ui/common/scaling_list_item.dart
@@ -1,4 +1,5 @@
 import 'package:wonders/common_libs.dart';
+import 'package:wonders/ui/common/global_coords_builder.dart';
 import 'package:wonders/ui/common/utils/context_utils.dart';
 
 class AnimatedListItem extends StatelessWidget {
@@ -14,17 +15,18 @@ class AnimatedListItem extends StatelessWidget {
         valueListenable: scrollPos,
         builder: (_, value, __) {
           return LayoutBuilder(
-            builder: (_, constraints) {
-              Offset? pos = ContextUtils.getGlobalPos(context);
-              final yPos = pos?.dy;
-              final widgetHeight = constraints.maxHeight;
-              double pctVisible = 0;
-              if (yPos != null) {
-                final amtVisible = context.heightPx - yPos;
-                pctVisible = (amtVisible / widgetHeight * .5).clamp(0, 1);
-              }
-              return builder(context, pctVisible);
-            },
+            builder: (_, constraints) => GlobalCoordsBuilder(
+              builder: (_, globalOffset, size) {
+                final yPos = globalOffset?.dy;
+                final widgetHeight = constraints.maxHeight;
+                double pctVisible = 0;
+                if (yPos != null) {
+                  final amtVisible = context.heightPx - yPos;
+                  pctVisible = (amtVisible / widgetHeight * .5).clamp(0, 1);
+                }
+                return builder(context, pctVisible);
+              },
+            ),
           );
         },
       ),

--- a/lib/ui/common/utils/context_utils.dart
+++ b/lib/ui/common/utils/context_utils.dart
@@ -3,16 +3,26 @@ import 'package:flutter/material.dart';
 class ContextUtils {
   static Offset? getGlobalPos(BuildContext context, [Offset offset = Offset.zero]) {
     final rb = context.findRenderObject() as RenderBox?;
-    if (rb?.hasSize == true) {
-      return rb?.localToGlobal(offset);
+    try {
+      if (rb?.hasSize == true && rb?.attached == true) {
+        return rb?.localToGlobal(offset);
+      }
+    } catch (e) {
+      // localToGlobal can throw if the render box is in the process of being removed from the tree
+      debugPrint('Error getting global position: $e');
     }
     return null;
   }
 
   static Size? getSize(BuildContext context) {
     final rb = context.findRenderObject() as RenderBox?;
-    if (rb?.hasSize == true) {
-      return rb?.size;
+    try {
+      if (rb?.hasSize == true && rb?.attached == true) {
+        return rb?.size;
+      }
+    } catch (e) {
+      // localToGlobal can throw if the render box is in the process of being removed from the tree
+      debugPrint('Error getting size: $e');
     }
     return null;
   }

--- a/lib/ui/common/utils/context_utils.dart
+++ b/lib/ui/common/utils/context_utils.dart
@@ -3,26 +3,16 @@ import 'package:flutter/material.dart';
 class ContextUtils {
   static Offset? getGlobalPos(BuildContext context, [Offset offset = Offset.zero]) {
     final rb = context.findRenderObject() as RenderBox?;
-    try {
-      if (rb?.hasSize == true && rb?.attached == true) {
-        return rb?.localToGlobal(offset);
-      }
-    } catch (e) {
-      // localToGlobal can throw if the render box is in the process of being removed from the tree
-      debugPrint('Error getting global position: $e');
+    if (rb?.hasSize == true) {
+      return rb?.localToGlobal(offset);
     }
     return null;
   }
 
   static Size? getSize(BuildContext context) {
     final rb = context.findRenderObject() as RenderBox?;
-    try {
-      if (rb?.hasSize == true && rb?.attached == true) {
-        return rb?.size;
-      }
-    } catch (e) {
-      // localToGlobal can throw if the render box is in the process of being removed from the tree
-      debugPrint('Error getting size: $e');
+    if (rb?.hasSize == true) {
+      return rb?.size;
     }
     return null;
   }

--- a/lib/ui/screens/editorial/editorial_screen.dart
+++ b/lib/ui/screens/editorial/editorial_screen.dart
@@ -16,6 +16,7 @@ import 'package:wonders/ui/common/compass_divider.dart';
 import 'package:wonders/ui/common/controls/trackpad_listener.dart';
 import 'package:wonders/ui/common/curved_clippers.dart';
 import 'package:wonders/ui/common/fullscreen_keyboard_list_scroller.dart';
+import 'package:wonders/ui/common/global_coords_builder.dart';
 import 'package:wonders/ui/common/google_maps_marker.dart';
 import 'package:wonders/ui/common/gradient_container.dart';
 import 'package:wonders/ui/common/hidden_collectible.dart';

--- a/lib/ui/screens/editorial/editorial_screen.dart
+++ b/lib/ui/screens/editorial/editorial_screen.dart
@@ -25,7 +25,6 @@ import 'package:wonders/ui/common/pop_router_on_over_scroll.dart';
 import 'package:wonders/ui/common/scaling_list_item.dart';
 import 'package:wonders/ui/common/static_text_scale.dart';
 import 'package:wonders/ui/common/themed_text.dart';
-import 'package:wonders/ui/common/utils/context_utils.dart';
 import 'package:wonders/ui/common/utils/duration_utils.dart';
 import 'package:wonders/ui/wonder_illustrations/common/wonder_illustration.dart';
 import 'package:wonders/ui/wonder_illustrations/common/wonder_illustration_config.dart';

--- a/lib/ui/screens/editorial/widgets/_collapsing_pull_quote_image.dart
+++ b/lib/ui/screens/editorial/widgets/_collapsing_pull_quote_image.dart
@@ -31,92 +31,94 @@ class _CollapsingPullQuoteImage extends StatelessWidget {
 
     return ValueListenableBuilder<double>(
       valueListenable: scrollPos,
-      builder: (context, value, __) {
-        double collapseAmt = 1.0;
-        final yPos = ContextUtils.getGlobalPos(context)?.dy;
-        if (yPos != null && yPos < collapseStartPx) {
-          // Get a normalized value, 0 - 1, representing the current amount of collapse.
-          collapseAmt = (collapseStartPx - max(collapseEndPx, yPos)) / (collapseStartPx - collapseEndPx);
-        }
+      builder: (context, value, __) => GlobalCoordsBuilder(
+        builder: (_, globalOffset, size) {
+          double collapseAmt = 1.0;
+          final yPos = globalOffset?.dy;
+          if (yPos != null && yPos < collapseStartPx) {
+            // Get a normalized value, 0 - 1, representing the current amount of collapse.
+            collapseAmt = (collapseStartPx - max(collapseEndPx, yPos)) / (collapseStartPx - collapseEndPx);
+          }
 
-        // The sized boxes in the column collapse to a zero height, allowing the quotes to naturally sit over top of the image
-        return MergeSemantics(
-          child: CenteredBox(
-            padding: EdgeInsets.symmetric(vertical: outerPadding),
-            width: imgHeight * .66,
-            child: Stack(
-              children: [
-                Container(
-                  width: context.widthPx,
-                  height: imgHeight,
-                  decoration: BoxDecoration(
-                    border: Border.all(color: $styles.colors.accent2),
-                    borderRadius: BorderRadius.only(
-                      topRight: Radius.circular(context.widthPx / 2),
-                      topLeft: Radius.circular(context.widthPx / 2),
-                    ),
-                  ),
-                ),
-
-                /// Main image
-                Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    SizedBox(
-                      height: imgHeight,
-
-                      // Clip the image with an curved top
-                      child: Stack(
-                        children: [
-                          Container(
-                            alignment: Alignment.topRight,
-                            margin: const EdgeInsets.all(12),
-                            child: ClipPath(
-                              clipper: CurvedTopClipper(),
-                              child: _buildImage(collapseAmt),
-                            ),
-                          ),
-                        ],
+          // The sized boxes in the column collapse to a zero height, allowing the quotes to naturally sit over top of the image
+          return MergeSemantics(
+            child: CenteredBox(
+              padding: EdgeInsets.symmetric(vertical: outerPadding),
+              width: imgHeight * .66,
+              child: Stack(
+                children: [
+                  Container(
+                    width: context.widthPx,
+                    height: imgHeight,
+                    decoration: BoxDecoration(
+                      border: Border.all(color: $styles.colors.accent2),
+                      borderRadius: BorderRadius.only(
+                        topRight: Radius.circular(context.widthPx / 2),
+                        topLeft: Radius.circular(context.widthPx / 2),
                       ),
                     ),
-                  ],
-                ),
+                  ),
 
-                /// Collapsing text
-                Positioned.fill(
-                  child: Container(
-                    margin: const EdgeInsets.symmetric(horizontal: 24),
-                    child: BlendMask(
-                      blendModes: const [BlendMode.colorBurn],
-                      child: StaticTextScale(
-                        child: Column(
-                          mainAxisAlignment: MainAxisAlignment.center,
+                  /// Main image
+                  Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      SizedBox(
+                        height: imgHeight,
+
+                        // Clip the image with an curved top
+                        child: Stack(
                           children: [
-                            SizedBox(height: 32), // push down vertical centre
-                            buildText(data.pullQuote1Top, collapseAmt, top: true),
-                            buildText(data.pullQuote1Bottom, collapseAmt, top: false),
-                            if (data.pullQuote1Author.isNotEmpty) ...[
-                              Container(
-                                margin: const EdgeInsets.only(top: 16),
-                                child: buildText(
-                                  '- ${data.pullQuote1Author}',
-                                  collapseAmt,
-                                  top: false,
-                                  isAuthor: true,
-                                ),
+                            Container(
+                              alignment: Alignment.topRight,
+                              margin: const EdgeInsets.all(12),
+                              child: ClipPath(
+                                clipper: CurvedTopClipper(),
+                                child: _buildImage(collapseAmt),
                               ),
-                            ],
+                            ),
                           ],
+                        ),
+                      ),
+                    ],
+                  ),
+
+                  /// Collapsing text
+                  Positioned.fill(
+                    child: Container(
+                      margin: const EdgeInsets.symmetric(horizontal: 24),
+                      child: BlendMask(
+                        blendModes: const [BlendMode.colorBurn],
+                        child: StaticTextScale(
+                          child: Column(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              SizedBox(height: 32), // push down vertical centre
+                              buildText(data.pullQuote1Top, collapseAmt, top: true),
+                              buildText(data.pullQuote1Bottom, collapseAmt, top: false),
+                              if (data.pullQuote1Author.isNotEmpty) ...[
+                                Container(
+                                  margin: const EdgeInsets.only(top: 16),
+                                  child: buildText(
+                                    '- ${data.pullQuote1Author}',
+                                    collapseAmt,
+                                    top: false,
+                                    isAuthor: true,
+                                  ),
+                                ),
+                              ],
+                            ],
+                          ),
                         ),
                       ),
                     ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
-          ),
-        );
-      },
+          );
+        },
+      ),
     );
   }
 

--- a/lib/ui/screens/editorial/widgets/_section_divider.dart
+++ b/lib/ui/screens/editorial/widgets/_section_divider.dart
@@ -20,8 +20,8 @@ class _SectionDividerState extends State<_SectionDivider> with SingleTickerProvi
 
   double _getSwitchPt(BuildContext c) => c.heightPx * .5;
 
-  void _checkPosition(BuildContext context) {
-    final yPos = ContextUtils.getGlobalPos(context)?.dy;
+  void _checkPosition(BuildContext context, Offset? globalOffset) {
+    final yPos = globalOffset?.dy;
     if (yPos == null || yPos < 0) return;
     // Only allow headers to switch if it's above the switch pt
     bool activated = yPos < _getSwitchPt(context);
@@ -40,16 +40,18 @@ class _SectionDividerState extends State<_SectionDivider> with SingleTickerProvi
     // When scroll position changes, the divider needs to check whether it should mark itself as the active index
     return ValueListenableBuilder<double>(
       valueListenable: widget.scrollNotifier,
-      builder: (context, value, _) {
-        _checkPosition(context);
-        return ValueListenableBuilder<bool>(
-          valueListenable: _isActivated,
-          builder: (_, value, __) => Padding(
-            padding: EdgeInsets.symmetric(vertical: $styles.insets.xl * 2),
-            child: CompassDivider(isExpanded: value),
-          ),
-        );
-      },
+      builder: (context, value, _) => GlobalCoordsBuilder(
+        builder: (_, globalOffset, size) {
+          _checkPosition(context, globalOffset);
+          return ValueListenableBuilder<bool>(
+            valueListenable: _isActivated,
+            builder: (_, value, __) => Padding(
+              padding: EdgeInsets.symmetric(vertical: $styles.insets.xl * 2),
+              child: CompassDivider(isExpanded: value),
+            ),
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/ui/screens/editorial/widgets/_sliding_image_stack.dart
+++ b/lib/ui/screens/editorial/widgets/_sliding_image_stack.dart
@@ -30,40 +30,42 @@ class _SlidingImageStack extends StatelessWidget {
         padding: const EdgeInsets.all(8.0),
         child: ValueListenableBuilder(
           valueListenable: scrollPos,
-          builder: (context, value, child) {
-            double pctVisible = 0;
-            final yPos = ContextUtils.getGlobalPos(context)?.dy;
-            final height = ContextUtils.getSize(context)?.height;
-            if (yPos != null && height != null) {
-              final amtVisible = context.heightPx - yPos;
-              pctVisible = (amtVisible / height).clamp(0, 3);
-            }
-            return Stack(
-              children: [
-                TopRight(
-                  child: FractionalTranslation(
-                    translation: Offset(0, -.1 + .2 * pctVisible),
-                    child: buildPhoto(
-                      .73,
-                      type.photo3,
-                      Alignment(0, -.3 + .6 * pctVisible),
+          builder: (context, value, child) => GlobalCoordsBuilder(
+            builder: (_, globalOffset, size) {
+              double pctVisible = 0;
+              final yPos = globalOffset?.dy;
+              final height = size?.height;
+              if (yPos != null && height != null) {
+                final amtVisible = context.heightPx - yPos;
+                pctVisible = (amtVisible / height).clamp(0, 3);
+              }
+              return Stack(
+                children: [
+                  TopRight(
+                    child: FractionalTranslation(
+                      translation: Offset(0, -.1 + .2 * pctVisible),
+                      child: buildPhoto(
+                        .73,
+                        type.photo3,
+                        Alignment(0, -.3 + .6 * pctVisible),
+                      ),
                     ),
                   ),
-                ),
-                BottomLeft(
-                  child: FractionalTranslation(
-                    translation: Offset(0, -.14 * pctVisible),
-                    child: buildPhoto(
-                      .45,
-                      type.photo4,
-                      Alignment(0, .3 - .6 * pctVisible),
-                      top: false,
+                  BottomLeft(
+                    child: FractionalTranslation(
+                      translation: Offset(0, -.14 * pctVisible),
+                      child: buildPhoto(
+                        .45,
+                        type.photo4,
+                        Alignment(0, .3 - .6 * pctVisible),
+                        top: false,
+                      ),
                     ),
                   ),
-                ),
-              ],
-            );
-          },
+                ],
+              );
+            },
+          ),
         ),
       ),
     );

--- a/lib/ui/screens/editorial/widgets/_title_text.dart
+++ b/lib/ui/screens/editorial/widgets/_title_text.dart
@@ -51,11 +51,13 @@ class _TitleText extends StatelessWidget {
                     sortKey: OrdinalSortKey(0),
                     child: AnimatedBuilder(
                       animation: scroller,
-                      builder: (_, __) {
-                        final yPos = ContextUtils.getGlobalPos(context)?.dy ?? 0;
-                        bool enableHero = yPos > -100;
-                        return WonderTitleText(data, enableHero: enableHero);
-                      },
+                      builder: (context, _) => GlobalCoordsBuilder(
+                        builder: (context, globalOffset, size) {
+                          final yPos = globalOffset?.dy ?? 0;
+                          bool enableHero = yPos > -100;
+                          return WonderTitleText(data, enableHero: enableHero);
+                        },
+                      ),
                     ),
                   ),
                   Gap($styles.insets.xs),


### PR DESCRIPTION
Issue: https://github.com/gskinnerTeam/flutter-wonderous-app/issues/222
The latest Flutter version introduced a RenderBox error that appears when trying to reference RenderBox's localToGlobal or size when the view is off the screen, which occurs from the Collecable_found screen transitioning to Collectables.

Solution:
- Created a GlobalCoordsBuilder wrapper that provides the global offset and size parameters gotten by RenderBox and ContextUtils.
- Wrapped up all editorial_views that load the global offset and size parameters from ContextUtils.