### PR TITLE
Reduce unnecessary rebuilds in timeline

### DIFF
--- a/lib/ui/screens/timeline/timeline_screen.dart
+++ b/lib/ui/screens/timeline/timeline_screen.dart
@@ -49,58 +49,61 @@ class _TimelineScreenState extends State<TimelineScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return LayoutBuilder(
-      builder: (_, constraints) {
-        // Determine min and max size of the timeline based on the size available to this widget
-        const double scrubberSize = 80;
-        const double minSize = 1200;
-        const double maxSize = 5500;
-        return Container(
-          color: $styles.colors.black,
-          child: Padding(
-            padding: EdgeInsets.only(bottom: 0),
-            child: Column(
-              children: [
-                AppHeader(title: $strings.timelineTitleGlobalTimeline),
+    return Provider<WonderType?>(
+      create: (_) => widget.type,
+      child: LayoutBuilder(
+        builder: (_, constraints) {
+          // Determine min and max size of the timeline based on the size available to this widget
+          const double scrubberSize = 80;
+          const double minSize = 1200;
+          const double maxSize = 5500;
+          return Container(
+            color: $styles.colors.black,
+            child: Padding(
+              padding: EdgeInsets.only(bottom: 0),
+              child: Column(
+                children: [
+                  AppHeader(title: $strings.timelineTitleGlobalTimeline),
 
-                /// Vertically scrolling timeline, manages a ScrollController.
-                Expanded(
-                  child: _ScrollingViewport(
-                    scroller: _scroller,
-                    minSize: minSize,
-                    maxSize: maxSize,
-                    selectedWonder: widget.type,
-                    onYearChanged: _handleViewportYearChanged,
-                  ),
-                ),
-
-                /// Era Text (classical, modern etc)
-                ValueListenableBuilder<int>(
-                  valueListenable: _year,
-                  builder: (_, value, __) => _AnimatedEraText(value),
-                ),
-                Gap($styles.insets.xs),
-
-                /// Mini Horizontal timeline, reacts to the state of the larger scrolling timeline,
-                /// and changes the timelines scroll position on Hz drag
-                CenteredBox(
-                  width: $styles.sizes.maxContentWidth1,
-                  child: Padding(
-                    padding: EdgeInsets.symmetric(horizontal: $styles.insets.lg),
-                    child: _BottomScrubber(
-                      _scroller,
-                      size: scrubberSize,
-                      timelineMinSize: minSize,
+                  /// Vertically scrolling timeline, manages a ScrollController.
+                  Expanded(
+                    child: _ScrollingViewport(
+                      scroller: _scroller,
+                      minSize: minSize,
+                      maxSize: maxSize,
                       selectedWonder: widget.type,
+                      onYearChanged: _handleViewportYearChanged,
                     ),
                   ),
-                ),
-                Gap($styles.insets.lg),
-              ],
+
+                  /// Era Text (classical, modern etc)
+                  ValueListenableBuilder<int>(
+                    valueListenable: _year,
+                    builder: (_, value, __) => _AnimatedEraText(value),
+                  ),
+                  Gap($styles.insets.xs),
+
+                  /// Mini Horizontal timeline, reacts to the state of the larger scrolling timeline,
+                  /// and changes the timelines scroll position on Hz drag
+                  CenteredBox(
+                    width: $styles.sizes.maxContentWidth1,
+                    child: Padding(
+                      padding: EdgeInsets.symmetric(horizontal: $styles.insets.lg),
+                      child: _BottomScrubber(
+                        _scroller,
+                        size: scrubberSize,
+                        timelineMinSize: minSize,
+                        selectedWonder: widget.type,
+                      ),
+                    ),
+                  ),
+                  Gap($styles.insets.lg),
+                ],
+              ),
             ),
-          ),
-        );
-      },
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/ui/screens/timeline/timeline_screen.dart
+++ b/lib/ui/screens/timeline/timeline_screen.dart
@@ -71,7 +71,6 @@ class _TimelineScreenState extends State<TimelineScreen> {
                       scroller: _scroller,
                       minSize: minSize,
                       maxSize: maxSize,
-                      selectedWonder: widget.type,
                       onYearChanged: _handleViewportYearChanged,
                     ),
                   ),

--- a/lib/ui/screens/timeline/timeline_screen.dart
+++ b/lib/ui/screens/timeline/timeline_screen.dart
@@ -92,7 +92,6 @@ class _TimelineScreenState extends State<TimelineScreen> {
                         _scroller,
                         size: scrubberSize,
                         timelineMinSize: minSize,
-                        selectedWonder: widget.type,
                       ),
                     ),
                   ),

--- a/lib/ui/screens/timeline/widgets/_bottom_scrubber.dart
+++ b/lib/ui/screens/timeline/widgets/_bottom_scrubber.dart
@@ -6,12 +6,10 @@ class _BottomScrubber extends StatelessWidget {
     super.key,
     required this.timelineMinSize,
     required this.size,
-    required this.selectedWonder,
   });
   final ScrollController? scroller;
   final double timelineMinSize;
   final double size;
-  final WonderType? selectedWonder;
 
   /// Calculate what fraction the scroller has travelled
   double _calculateScrollFraction(ScrollPosition? pos) {
@@ -34,6 +32,7 @@ class _BottomScrubber extends StatelessWidget {
     /// It might take a frame until we receive a valid scroller
     if (scroller == null) return SizedBox.shrink();
 
+    final selectedWonder = context.watch<WonderType?>();
     return LayoutBuilder(
       builder: (context, constraints) {
         void handleScrubberPan(DragUpdateDetails details) {

--- a/lib/ui/screens/timeline/widgets/_bottom_scrubber.dart
+++ b/lib/ui/screens/timeline/widgets/_bottom_scrubber.dart
@@ -7,7 +7,7 @@ class _BottomScrubber extends StatelessWidget {
     required this.timelineMinSize,
     required this.size,
   });
-  final ScrollController? scroller;
+  final ScrollController scroller;
   final double timelineMinSize;
   final double size;
 
@@ -27,11 +27,6 @@ class _BottomScrubber extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final scroller = this.scroller;
-
-    /// It might take a frame until we receive a valid scroller
-    if (scroller == null) return SizedBox.shrink();
-
     final selectedWonder = context.watch<WonderType?>();
     return LayoutBuilder(
       builder: (context, constraints) {

--- a/lib/ui/screens/timeline/widgets/_dashed_divider_with_year.dart
+++ b/lib/ui/screens/timeline/widgets/_dashed_divider_with_year.dart
@@ -1,41 +1,46 @@
 part of '../timeline_screen.dart';
 
 class _DashedDividerWithYear extends StatelessWidget {
-  const _DashedDividerWithYear(this.year, {super.key});
-  final int year;
+  const _DashedDividerWithYear({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final currentYearNotifier = context.watch<CurrentYearNotifier>();
     int yrGap = 10;
-    final roundedYr = (year / yrGap).round() * yrGap;
     return Stack(
       children: [
         Center(child: DashedLine()),
         CenterRight(
           child: FractionalTranslation(
             translation: Offset(0, -.5),
-            child: MergeSemantics(
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    '${roundedYr.abs()}',
-                    style: $styles.text.h2.copyWith(
-                      color: $styles.colors.white,
-                      shadows: $styles.shadows.text,
-                    ),
+            child: ValueListenableBuilder(
+              valueListenable: currentYearNotifier,
+              builder: (_, currentYear, _) {
+                final roundedYr = (currentYear / yrGap).round() * yrGap;
+                return MergeSemantics(
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        '${roundedYr.abs()}',
+                        style: $styles.text.h2.copyWith(
+                          color: $styles.colors.white,
+                          shadows: $styles.shadows.text,
+                        ),
+                      ),
+                      Gap($styles.insets.xs),
+                      Text(
+                        StringUtils.getYrSuffix(roundedYr),
+                        style: $styles.text.body.copyWith(
+                          color: Colors.white,
+                          shadows: $styles.shadows.textStrong,
+                        ),
+                      ),
+                      Gap($styles.insets.xs),
+                    ],
                   ),
-                  Gap($styles.insets.xs),
-                  Text(
-                    StringUtils.getYrSuffix(roundedYr),
-                    style: $styles.text.body.copyWith(
-                      color: Colors.white,
-                      shadows: $styles.shadows.textStrong,
-                    ),
-                  ),
-                  Gap($styles.insets.xs),
-                ],
-              ),
+                );
+              },
             ),
           ),
         ),

--- a/lib/ui/screens/timeline/widgets/_event_markers.dart
+++ b/lib/ui/screens/timeline/widgets/_event_markers.dart
@@ -63,7 +63,7 @@ class _EventMarkersState extends State<_EventMarkers> {
   );
 
   //Store reference to the notifier for listeners
-  late CurrentYearNotifier _notifier;
+  late final CurrentYearNotifier _notifier;
 
   @override
   void initState() {
@@ -152,7 +152,6 @@ class _EventMarker extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    print("marker");
     return Align(
       alignment: Alignment(0, -1 + offset * 2),
       // Use an OverflowBox wrapped in a zero-height sized box so that al

--- a/lib/ui/screens/timeline/widgets/_event_markers.dart
+++ b/lib/ui/screens/timeline/widgets/_event_markers.dart
@@ -3,8 +3,7 @@ part of '../timeline_screen.dart';
 /// A vertically aligned stack of dots that represent global events
 /// The event closest to the [selectedYr] param will be visible selected
 class _EventMarkers extends StatefulWidget {
-  const _EventMarkers(
-    this.selectedYr, {
+  const _EventMarkers({
     super.key,
     required this.onEventChanged,
     required this.onMarkerPressed,
@@ -12,7 +11,6 @@ class _EventMarkers extends StatefulWidget {
 
   final void Function(TimelineEvent? event) onEventChanged;
   final void Function(TimelineEvent event) onMarkerPressed;
-  final int selectedYr;
 
   @override
   State<_EventMarkers> createState() => _EventMarkersState();
@@ -31,18 +29,20 @@ class _EventMarkersState extends State<_EventMarkers> {
   /// Normalizes a given year to a value from 0 - 1, based on start and end yr.
   double _calculateOffsetY(int yr) => (yr - startYr) / _totalYrs;
 
+  late BoxConstraints _constraints;
+
   /// Loops through the global events, and does a px-based check to see whether
   /// one of them should be selected  (as oppose to year-based proximity).
   /// This ensures consistent UX at different zoom levels.
-  void _updateSelectedEvent(double maxPxHeight) {
+  void _updateSelectedEvent() {
     const double minDistance = 10;
     TimelineEvent? closestEvent;
     double closestDistance = double.infinity;
     // Convert current yr to a px position
-    double currentYearPx = _calculateOffsetY(widget.selectedYr) * maxPxHeight;
+    double currentYearPx = _calculateOffsetY(_currentYr.value) * _constraints.maxHeight;
     for (var e in timelineLogic.events) {
       // Convert both the event.yr to px, and compare with currentYearPx
-      double eventPx = _calculateOffsetY(e.year) * maxPxHeight;
+      double eventPx = _eventOffsetCache[e]! * _constraints.maxHeight;
       double d = (eventPx - currentYearPx).abs();
       // Keep the closest event that is within minDistance
       if (d <= minDistance && d < closestDistance) {
@@ -53,8 +53,29 @@ class _EventMarkersState extends State<_EventMarkers> {
     // Dispatch if event has actually changed since last time
     if (closestEvent != selectedEvent) {
       scheduleMicrotask(() => widget.onEventChanged(closestEvent));
+      setState(() => selectedEvent = closestEvent);
     }
-    selectedEvent = closestEvent;
+  }
+
+  //Calculate the offsets for each event only once
+  late final Map<TimelineEvent, double> _eventOffsetCache = Map.fromEntries(
+    timelineLogic.events.map((e) => MapEntry(e, _calculateOffsetY(e.year))),
+  );
+
+  //Store reference to the notifier for listeners
+  late ValueNotifier<int> _currentYr;
+
+  @override
+  void initState() {
+    super.initState();
+    _currentYr = context.read<CurrentYearNotifier>();
+    _currentYr.addListener(_updateSelectedEvent);
+  }
+
+  @override
+  void dispose() {
+    _currentYr.removeListener(_updateSelectedEvent);
+    super.dispose();
   }
 
   @override
@@ -62,19 +83,19 @@ class _EventMarkersState extends State<_EventMarkers> {
     return IgnorePointerKeepSemantics(
       child: LayoutBuilder(
         builder: (_, constraints) {
-          /// Figure out which event is "selected"
-          _updateSelectedEvent(constraints.maxHeight);
+          //Store latest constraints in local variable
+          _constraints = constraints;
 
           /// Create a marker for each event
-          List<Widget> markers = timelineLogic.events.map((event) {
-            double offsetY = _calculateOffsetY(event.year);
+          final markers = timelineLogic.events.map((event) {
+            double offsetY = _eventOffsetCache[event]!;
             return _EventMarker(
               offsetY,
               event: event,
               isSelected: event == selectedEvent,
               onPressed: widget.onMarkerPressed,
             );
-          }).toList();
+          });
 
           /// Stack of fractionally positioned markers
           return FocusTraversalGroup(
@@ -131,6 +152,7 @@ class _EventMarker extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    print("marker");
     return Align(
       alignment: Alignment(0, -1 + offset * 2),
       // Use an OverflowBox wrapped in a zero-height sized box so that al

--- a/lib/ui/screens/timeline/widgets/_event_markers.dart
+++ b/lib/ui/screens/timeline/widgets/_event_markers.dart
@@ -39,7 +39,7 @@ class _EventMarkersState extends State<_EventMarkers> {
     TimelineEvent? closestEvent;
     double closestDistance = double.infinity;
     // Convert current yr to a px position
-    double currentYearPx = _calculateOffsetY(_currentYr.value) * _constraints.maxHeight;
+    double currentYearPx = _calculateOffsetY(_notifier.value) * _constraints.maxHeight;
     for (var e in timelineLogic.events) {
       // Convert both the event.yr to px, and compare with currentYearPx
       double eventPx = _eventOffsetCache[e]! * _constraints.maxHeight;
@@ -63,18 +63,18 @@ class _EventMarkersState extends State<_EventMarkers> {
   );
 
   //Store reference to the notifier for listeners
-  late ValueNotifier<int> _currentYr;
+  late CurrentYearNotifier _notifier;
 
   @override
   void initState() {
     super.initState();
-    _currentYr = context.read<CurrentYearNotifier>();
-    _currentYr.addListener(_updateSelectedEvent);
+    _notifier = context.read<CurrentYearNotifier>();
+    _notifier.addListener(_updateSelectedEvent);
   }
 
   @override
   void dispose() {
-    _currentYr.removeListener(_updateSelectedEvent);
+    _notifier.removeListener(_updateSelectedEvent);
     super.dispose();
   }
 

--- a/lib/ui/screens/timeline/widgets/_scrolling_viewport.dart
+++ b/lib/ui/screens/timeline/widgets/_scrolling_viewport.dart
@@ -91,14 +91,9 @@ class _ScalingViewportState extends State<_ScrollingViewport> {
     Widget buildTimelineSection(WonderData data) {
       return ClipRRect(
         borderRadius: BorderRadius.circular(99),
-        child: AnimatedBuilder(
-          animation: controller.scroller,
-          builder: (_, __) => Provider<WonderData>(
-            create: (_) => data,
-            child: TimelineSection(
-              controller.calculateYearFromScrollPos(),
-            ),
-          ),
+        child: Provider<WonderData>(
+          create: (_) => data,
+          child: const TimelineSection(),
         ),
       );
     }

--- a/lib/ui/screens/timeline/widgets/_scrolling_viewport.dart
+++ b/lib/ui/screens/timeline/widgets/_scrolling_viewport.dart
@@ -44,7 +44,7 @@ class _ScalingViewportState extends State<_ScrollingViewport> {
     AppHaptics.selectionClick();
   }
 
-  void _handleMarkerPressed(event) {
+  void _handleMarkerPressed(TimelineEvent event) {
     final pos = controller.calculateScrollPosFromYear(event.year);
     controller.scroller.animateTo(pos, duration: $styles.times.med, curve: Curves.easeOutBack);
   }

--- a/lib/ui/screens/timeline/widgets/_scrolling_viewport.dart
+++ b/lib/ui/screens/timeline/widgets/_scrolling_viewport.dart
@@ -75,13 +75,8 @@ class _ScalingViewportState extends State<_ScrollingViewport> {
               _buildScrollingArea(context).maybeAnimate().fadeIn(),
 
               // Dashed line with a year that changes as we scroll
-            // Dashed line with a year that changes as we scroll
-            IgnorePointerKeepSemantics(
-              child: AnimatedBuilder(
-                animation: controller.scroller,
-                builder: (_, __) {
-                  return _DashedDividerWithYear(controller.calculateYearFromScrollPos());
-                },
+              const IgnorePointerKeepSemantics(
+                child: _DashedDividerWithYear(),
               ),
             ],
           ),

--- a/lib/ui/screens/timeline/widgets/_scrolling_viewport.dart
+++ b/lib/ui/screens/timeline/widgets/_scrolling_viewport.dart
@@ -55,23 +55,26 @@ class _ScalingViewportState extends State<_ScrollingViewport> {
       scheduleMicrotask(controller._handleResize);
     }
     _prevSize = context.mq.size;
-    return Listener(
-      onPointerSignal: (PointerSignalEvent e) {
-        if (HardwareKeyboard.instance.isControlPressed) {
-          controller._handleScaleUpdateMouse(((e as PointerScaleEvent).scale - 1) * 0.25);
-        }
-      },
-      child: GestureDetector(
-        // Handle pinch to zoom
-        onScaleUpdate: controller._handleScaleUpdate,
-        onScaleStart: controller._handleScaleStart,
-        behavior: HitTestBehavior.translucent,
-        // Fade in entire view when first shown
-        child: Stack(
-          children: [
-            // Main content area
-            _buildScrollingArea(context).maybeAnimate().fadeIn(),
+    return ChangeNotifierProvider<CurrentYearNotifier>(
+      create: (_) => controller.currentYr,
+      child: Listener(
+        onPointerSignal: (PointerSignalEvent e) {
+          if (HardwareKeyboard.instance.isControlPressed) {
+            controller._handleScaleUpdateMouse(((e as PointerScaleEvent).scale - 1) * 0.25);
+          }
+        },
+        child: GestureDetector(
+          // Handle pinch to zoom
+          onScaleUpdate: controller._handleScaleUpdate,
+          onScaleStart: controller._handleScaleStart,
+          behavior: HitTestBehavior.translucent,
+          // Fade in entire view when first shown
+          child: Stack(
+            children: [
+              // Main content area
+              _buildScrollingArea(context).maybeAnimate().fadeIn(),
 
+              // Dashed line with a year that changes as we scroll
             // Dashed line with a year that changes as we scroll
             IgnorePointerKeepSemantics(
               child: AnimatedBuilder(
@@ -80,8 +83,8 @@ class _ScalingViewportState extends State<_ScrollingViewport> {
                   return _DashedDividerWithYear(controller.calculateYearFromScrollPos());
                 },
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/ui/screens/timeline/widgets/_scrolling_viewport.dart
+++ b/lib/ui/screens/timeline/widgets/_scrolling_viewport.dart
@@ -8,13 +8,11 @@ class _ScrollingViewport extends StatefulWidget {
     required this.scroller,
     required this.minSize,
     required this.maxSize,
-    required this.selectedWonder,
     this.onYearChanged,
   });
   final double minSize;
   final double maxSize;
   final ScrollController scroller;
-  final WonderType? selectedWonder;
   final void Function(int year)? onYearChanged;
   final void Function(_ScrollingViewportController controller)? onInit;
 
@@ -31,7 +29,7 @@ class _ScalingViewportState extends State<_ScrollingViewport> {
   @override
   void initState() {
     super.initState();
-    controller.init();
+    controller.init(context.read<WonderType?>());
     widget.onInit?.call(controller);
   }
 

--- a/lib/ui/screens/timeline/widgets/_scrolling_viewport.dart
+++ b/lib/ui/screens/timeline/widgets/_scrolling_viewport.dart
@@ -97,10 +97,12 @@ class _ScalingViewportState extends State<_ScrollingViewport> {
         borderRadius: BorderRadius.circular(99),
         child: AnimatedBuilder(
           animation: controller.scroller,
-          builder: (_, __) => TimelineSection(
-            data,
-            controller.calculateYearFromScrollPos(),
-            selectedWonder: widget.selectedWonder,
+          builder: (_, __) => Provider<WonderData>(
+            create: (_) => data,
+            child: TimelineSection(
+              controller.calculateYearFromScrollPos(),
+              selectedWonder: widget.selectedWonder,
+            ),
           ),
         ),
       );

--- a/lib/ui/screens/timeline/widgets/_scrolling_viewport.dart
+++ b/lib/ui/screens/timeline/widgets/_scrolling_viewport.dart
@@ -134,14 +134,9 @@ class _ScalingViewportState extends State<_ScrollingViewport> {
                       ),
                     ),
 
-                    /// Event Markers, rebuilds on scroll
-                    AnimatedBuilder(
-                      animation: controller.scroller,
-                      builder: (_, __) => _EventMarkers(
-                        controller.calculateYearFromScrollPos(),
-                        onEventChanged: _handleEventMarkerChanged,
-                        onMarkerPressed: _handleMarkerPressed,
-                      ),
+                    _EventMarkers(
+                      onEventChanged: _handleEventMarkerChanged,
+                      onMarkerPressed: _handleMarkerPressed,
                     ),
                   ],
                 ),

--- a/lib/ui/screens/timeline/widgets/_scrolling_viewport.dart
+++ b/lib/ui/screens/timeline/widgets/_scrolling_viewport.dart
@@ -101,7 +101,6 @@ class _ScalingViewportState extends State<_ScrollingViewport> {
             create: (_) => data,
             child: TimelineSection(
               controller.calculateYearFromScrollPos(),
-              selectedWonder: widget.selectedWonder,
             ),
           ),
         ),

--- a/lib/ui/screens/timeline/widgets/_scrolling_viewport_controller.dart
+++ b/lib/ui/screens/timeline/widgets/_scrolling_viewport_controller.dart
@@ -34,14 +34,14 @@ class _ScrollingViewportController extends ChangeNotifier {
     });
   }
 
-  void _updateCurrentYear() => _currentYr.value = calculateYearFromScrollPos();
+  void _updateCurrentYear() => currentYr.value = _calculateYearFromScrollPos();
 
   /// Allows ancestors to set zoom directly
   void setZoom(double d) {
     // ignore: invalid_use_of_protected_member
     state.setState(() {
       // Determine current yr, based on scroll position
-      int currentYr = calculateYearFromScrollPos();
+      int currentYr = _calculateYearFromScrollPos();
 
       // Change zoom, which will scale our content, and change our scroll position
       _zoom = d;
@@ -71,7 +71,7 @@ class _ScrollingViewportController extends ChangeNotifier {
   }
 
   /// Derive current yr based on the scroll position and the current content height.
-  int calculateYearFromScrollPos() {
+  int _calculateYearFromScrollPos() {
     if (scroller.hasClients == false) return startYr;
     int totalYrs = endYr - startYr;
     double currentPx = scroller.position.pixels;
@@ -99,5 +99,5 @@ class _ScrollingViewportController extends ChangeNotifier {
   }
 
   /// Maintain current yr when the app changes size
-  void _handleResize() => jumpToYear(_currentYr.value);
+  void _handleResize() => jumpToYear(currentYr.value);
 }

--- a/lib/ui/screens/timeline/widgets/_scrolling_viewport_controller.dart
+++ b/lib/ui/screens/timeline/widgets/_scrolling_viewport_controller.dart
@@ -17,10 +17,9 @@ class _ScrollingViewportController extends ChangeNotifier {
       () => state.widget.onYearChanged?.call(_currentYr.value),
     );
 
-  void init() {
+  void init(WonderType? w) {
     scheduleMicrotask(() {
       setZoom(.5);
-      final w = widget.selectedWonder;
       if (w != null) {
         final data = wondersLogic.getData(w);
         final pos = calculateScrollPosFromYear(data.startYr);

--- a/lib/ui/screens/timeline/widgets/_scrolling_viewport_controller.dart
+++ b/lib/ui/screens/timeline/widgets/_scrolling_viewport_controller.dart
@@ -1,5 +1,9 @@
 part of '../timeline_screen.dart';
 
+class CurrentYearNotifier extends ValueNotifier<int> {
+  CurrentYearNotifier(super.value);
+}
+
 class _ScrollingViewportController extends ChangeNotifier {
   _ScrollingViewportController(this.state);
   final _ScalingViewportState state;
@@ -12,9 +16,9 @@ class _ScrollingViewportController extends ChangeNotifier {
   late BoxConstraints _constraints;
   _ScrollingViewport get widget => state.widget;
   ScrollController get scroller => widget.scroller;
-  late final ValueNotifier<int> _currentYr = ValueNotifier(startYr)
+  late final CurrentYearNotifier currentYr = CurrentYearNotifier(startYr)
     ..addListener(
-      () => state.widget.onYearChanged?.call(_currentYr.value),
+      () => state.widget.onYearChanged?.call(currentYr.value),
     );
 
   void init(WonderType? w) {

--- a/lib/ui/screens/timeline/widgets/_timeline_section.dart
+++ b/lib/ui/screens/timeline/widgets/_timeline_section.dart
@@ -1,14 +1,12 @@
 part of '../timeline_screen.dart';
 
 class TimelineSection extends StatelessWidget {
-  const TimelineSection(this.selectedYr, {super.key, required this.selectedWonder});
+  const TimelineSection(this.selectedYr, {super.key});
   final int selectedYr;
-  final WonderType? selectedWonder;
 
   @override
   Widget build(BuildContext context) {
     final data = context.watch<WonderData>();
-    bool isSelected = selectedWonder == data.type;
     // get a fraction from 0 - 1 based on selected yr and start/end yr of the wonder
     // 500, 250, 750
     int startYr = data.startYr, endYr = data.endYr;
@@ -26,14 +24,7 @@ class TimelineSection extends StatelessWidget {
           alignment: Alignment(0, -1 + fraction * 2),
           padding: EdgeInsets.all($styles.insets.xs),
           decoration: BoxDecoration(color: data.type.fgColor),
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(99),
-            child: BlendMask(
-              blendModes: isSelected ? [] : const [BlendMode.luminosity],
-              opacity: .6,
-              child: const _WonderImage(),
-            ),
-          ),
+          child: const _WonderImage(),
         ),
       ),
     );
@@ -46,14 +37,23 @@ class _WonderImage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final data = context.watch<WonderData>();
-    return Container(
-      height: 160,
-      decoration: BoxDecoration(
-        color: data.type.bgColor,
-        image: DecorationImage(
-          fit: BoxFit.cover,
-          alignment: Alignment(0, -.5),
-          image: AssetImage(data.type.flattened),
+    final selectedWonder = context.watch<WonderType?>();
+    bool isSelected = selectedWonder == data.type;
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(99),
+      child: BlendMask(
+        blendModes: isSelected ? [] : const [BlendMode.luminosity],
+        opacity: .6,
+        child: Container(
+          height: 160,
+          decoration: BoxDecoration(
+            color: data.type.bgColor,
+            image: DecorationImage(
+              fit: BoxFit.cover,
+              alignment: Alignment(0, -.5),
+              image: AssetImage(data.type.flattened),
+            ),
+          ),
         ),
       ),
     );

--- a/lib/ui/screens/timeline/widgets/_timeline_section.dart
+++ b/lib/ui/screens/timeline/widgets/_timeline_section.dart
@@ -1,32 +1,37 @@
 part of '../timeline_screen.dart';
 
 class TimelineSection extends StatelessWidget {
-  const TimelineSection(this.selectedYr, {super.key});
-  final int selectedYr;
+  const TimelineSection({super.key});
 
   @override
   Widget build(BuildContext context) {
     final data = context.watch<WonderData>();
-    // get a fraction from 0 - 1 based on selected yr and start/end yr of the wonder
-    // 500, 250, 750
-    int startYr = data.startYr, endYr = data.endYr;
-    double fraction = (selectedYr - startYr) / (endYr - startYr);
-    fraction = fraction.clamp(0, 1);
 
-    return Semantics(
-      label:
-          '${data.title}, ${$strings.timelineSemanticDate(
-            StringUtils.formatYr(data.startYr),
-            StringUtils.formatYr(data.endYr),
-          )}',
-      child: IgnorePointerKeepSemantics(
-        child: Container(
-          alignment: Alignment(0, -1 + fraction * 2),
-          padding: EdgeInsets.all($styles.insets.xs),
-          decoration: BoxDecoration(color: data.type.fgColor),
-          child: const _WonderImage(),
-        ),
-      ),
+    return ValueListenableBuilder(
+      valueListenable: context.watch<CurrentYearNotifier>(),
+      builder: (_, currentYear, child) {
+        // get a fraction from 0 - 1 based on selected yr and start/end yr of the wonder
+        // 500, 250, 750
+        int startYr = data.startYr, endYr = data.endYr;
+        double fraction = (currentYear - startYr) / (endYr - startYr);
+        fraction = fraction.clamp(0, 1);
+        return Semantics(
+          label:
+              '${data.title}, ${$strings.timelineSemanticDate(
+                StringUtils.formatYr(data.startYr),
+                StringUtils.formatYr(data.endYr),
+              )}',
+          child: IgnorePointerKeepSemantics(
+            child: Container(
+              alignment: Alignment(0, -1 + fraction * 2),
+              padding: EdgeInsets.all($styles.insets.xs),
+              decoration: BoxDecoration(color: data.type.fgColor),
+              child: child,
+            ),
+          ),
+        );
+      },
+      child: const _WonderImage(),
     );
   }
 }

--- a/lib/ui/screens/timeline/widgets/_timeline_section.dart
+++ b/lib/ui/screens/timeline/widgets/_timeline_section.dart
@@ -1,13 +1,13 @@
 part of '../timeline_screen.dart';
 
 class TimelineSection extends StatelessWidget {
-  const TimelineSection(this.data, this.selectedYr, {super.key, required this.selectedWonder});
-  final WonderData data;
+  const TimelineSection(this.selectedYr, {super.key, required this.selectedWonder});
   final int selectedYr;
   final WonderType? selectedWonder;
 
   @override
   Widget build(BuildContext context) {
+    final data = context.watch<WonderData>();
     bool isSelected = selectedWonder == data.type;
     // get a fraction from 0 - 1 based on selected yr and start/end yr of the wonder
     // 500, 250, 750
@@ -31,15 +31,21 @@ class TimelineSection extends StatelessWidget {
             child: BlendMask(
               blendModes: isSelected ? [] : const [BlendMode.luminosity],
               opacity: .6,
-              child: _buildWonderImage(),
+              child: const _WonderImage(),
             ),
           ),
         ),
       ),
     );
   }
+}
 
-  Container _buildWonderImage() {
+class _WonderImage extends StatelessWidget {
+  const _WonderImage();
+
+  @override
+  Widget build(BuildContext context) {
+    final data = context.watch<WonderData>();
     return Container(
       height: 160,
       decoration: BoxDecoration(


### PR DESCRIPTION
I noticed that the timeline has quite a lot of unnecessary rebuilds so I thought I made a PR to reduce them. Since the provider package was already installed, I used it to reduce prop drilling and allow fine grained rebuilds. 

- Wrapped the `TimelineScreen` with a `Provider<WonderType?>> ` to provide the selected wonder to the entire subtree
- Wrapped each `TimelineSection` with a `Provider<WonderData>>`
- Created a `CurrentYearNotifier` to avoid potential clashes with future `Provider<ValueNotifier<int>>` 
- Created a `Provider<CurrentYearNotifier>>` to allow finer reactivity to changes of the selected year